### PR TITLE
Fix data type conversion for spark iotdb table connector

### DIFF
--- a/connectors/spark-iotdb-table-connector/spark-iotdb-table-common/src/main/scala/org/apache/iotdb/spark/table/db/IoTDBUtils.scala
+++ b/connectors/spark-iotdb-table-connector/spark-iotdb-table-common/src/main/scala/org/apache/iotdb/spark/table/db/IoTDBUtils.scala
@@ -127,7 +127,13 @@ object IoTDBUtils {
       case BinaryType => TSDataType.BLOB
       case DateType => TSDataType.DATE
       case TimestampType => TSDataType.STRING
-      case _ => TSDataType.STRING
+      case _ => {
+        var errMsg = s"Unable to convert Spark data type $sparkDataType to IoTDB data type."
+        if (sparkDataType.simpleString.toLowerCase.contains("decimal")) {
+          errMsg += s"For float numbers in insert into values sql, you should add the suffix 'f' or 'd' to represent float or double."
+        }
+        throw new IllegalArgumentException(errMsg)
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Fix data type conversion for spark iotdb table connector
1. Added error message for decimal type
2. For NullType, find the data type of the corresponding column from the table schema to construct the tablet to avoid data type inconsistency during writing