### PR TITLE
Add support for STRING type

### DIFF
--- a/connectors/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/DefaultIoTSerializationSchema.java
+++ b/connectors/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/DefaultIoTSerializationSchema.java
@@ -72,6 +72,7 @@ public class DefaultIoTSerializationSchema implements IoTSerializationSchema<Map
           values.add(Integer.parseInt(valuesStr[i]));
           break;
         case TEXT:
+        case STRING:
           values.add(valuesStr[i]);
           break;
         case FLOAT:

--- a/connectors/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
+++ b/connectors/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
@@ -183,8 +183,9 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
       for (int i = 0; i < measurements.size(); i++) {
         String measurement = device + TsFileConstant.PATH_SEPARATOR + measurements.get(i);
         IoTDBSinkOptions.TimeseriesOption timeseriesOption = timeseriesOptionMap.get(measurement);
-        if (timeseriesOption != null && TSDataType.TEXT.equals(timeseriesOption.getDataType())) {
-          // The TEXT data type should be covered by " or '
+        if (timeseriesOption != null && (TSDataType.TEXT.equals(timeseriesOption.getDataType()) ||
+                TSDataType.STRING.equals(timeseriesOption.getDataType()))) {
+          // The TEXT/STRING data type should be covered by " or '
           values.set(i, "'" + values.get(i) + "'");
         }
       }


### PR DESCRIPTION
## Description
I want to use STRING type data, but the current SINK does not support it.

### Why Use STRING type
IoTDB version 1.3.X has added support for the STRING type. The difference between STRING and TEXT types is that STRING type carries more statistical information, which can be used to optimize value-filtering queries. TEXT type is more suitable for storing long strings.

##### Key changed/added classes (or packages if there are too many classes) in this PR
DefaultIoTSerializationSchema.java -> serialize(Map<String, String> tuple)
IoTDBSink.java ->  convertText(String device, List<String> measurements, List<Object> values)