### PR TITLE
Add table-model query support to the Grafana data source plugin

### DIFF
--- a/connectors/grafana-plugin/README.md
+++ b/connectors/grafana-plugin/README.md
@@ -69,7 +69,7 @@ Click the `New Dashboard` icon on the top right, and select `Add an empty panel`
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Ecosystem%20Integration/Grafana-plugin/add%20empty%20panel.png?raw=true">
 
-Grafana plugin supports SQL: Full Customized mode and SQL: Drop-down List mode, and the default mode is SQL: Full Customized mode.
+Grafana plugin supports SQL: Full Customized mode and SQL: Drop-down List mode for the tree model, and SQL: Table Model mode for the table model. The default mode is SQL: Full Customized mode.
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Ecosystem%20Integration/Grafana-plugin/grafana_input_style.png?raw=true">
 
@@ -118,6 +118,35 @@ Tip: Statements like `select * from root.xx.**` are not recommended because thos
 Select a time series in the TIME-SERIES selection box, select a function in the FUNCTION option, and enter the contents in the SAMPLING INTERVAL、SLIDING STEP、LEVEL、FILL input boxes, where TIME-SERIES is a required item and the rest are non required items.
 
 <img style="width:100%; max-width:800px; max-height:600px; margin-left:auto; margin-right:auto; display:block;" src="https://github.com/apache/iotdb-bin-resources/blob/main/docs/UserGuide/Ecosystem%20Integration/Grafana-plugin/grafana_input2.png?raw=true">
+
+##### SQL: Table Model
+
+Queries IoTDB's table model (IoTDB 2.x) through the REST interface `/rest/table/v1/query`. Enter a standard SQL statement in the SQL input box, for example:
+
+```sql
+SELECT time, device_id, temperature FROM table1 WHERE $__timeFilter(time)
+```
+
+DATABASE input box: the database to run the statement against. Optional when every table reference in the statement is fully qualified (`database.table`).
+
+SQL input box: a single table-model SELECT statement. The following macros are expanded by the plugin before the statement is sent:
+
+| Macro | Expands to |
+| ----- | ---------- |
+| `$__timeFilter(col)` | `(col >= <panel start> AND col <= <panel end>)`; `col` defaults to `time` when omitted |
+| `$__timeFrom`, `$__timeFrom()` | the panel range start as an epoch integer |
+| `$__timeTo`, `$__timeTo()` | the panel range end as an epoch integer |
+
+FORMAT option:
+
+* `Time series` (default): rows are sorted by the first TIMESTAMP column, and a result that contains tag/string columns next to numeric columns is pivoted into one series per tag combination — so a query returning several devices renders as separate lines in a time-series panel. Note that the pivot requires timestamps without nulls; results are sorted by the plugin, so an `ORDER BY` clause is not needed.
+* `Table`: rows are returned exactly as the server sent them (use this with the table panel, or when your `ORDER BY` should be preserved).
+
+Result columns are typed from the response's `data_types`: TIMESTAMP columns become Grafana time fields, INT32/INT64 become integers, FLOAT/DOUBLE become floats, BOOLEAN becomes booleans, and TEXT/STRING/DATE/BLOB render as strings.
+
+If the server runs with a non-default `timestamp_precision` (`us` or `ns`), set the same value in the data source's `time precision` option — it controls both how TIMESTAMP values are interpreted and what the time macros expand to.
+
+The REST service caps query results at `rest_query_default_row_size_limit` rows (10000 by default, configurable on the server); a query exceeding it returns an error message rather than truncated data.
 
 #### Support for variables and template functions
 

--- a/connectors/grafana-plugin/README.md
+++ b/connectors/grafana-plugin/README.md
@@ -121,11 +121,13 @@ Select a time series in the TIME-SERIES selection box, select a function in the 
 
 ##### SQL: Table Model
 
-Queries IoTDB's table model (IoTDB 2.x) through the REST interface `/rest/table/v1/query`. Enter a standard SQL statement in the SQL input box, for example:
+Queries IoTDB's table model (IoTDB 2.x) through the native Go client ([apache/iotdb-client-go](https://github.com/apache/iotdb-client-go)). Enter a standard SQL statement in the SQL input box, for example:
 
 ```sql
 SELECT time, device_id, temperature FROM table1 WHERE $__timeFilter(time)
 ```
+
+Unlike the tree-model modes, which go through the REST service, this mode connects to the IoTDB RPC port (6667 by default). The data source's `rpc address` option sets that endpoint explicitly; when it is left empty, the URL's host with port 6667 is used.
 
 DATABASE input box: the database to run the statement against. Optional when every table reference in the statement is fully qualified (`database.table`).
 
@@ -134,19 +136,19 @@ SQL input box: a single table-model SELECT statement. The following macros are e
 | Macro | Expands to |
 | ----- | ---------- |
 | `$__timeFilter(col)` | `(col >= <panel start> AND col <= <panel end>)`; `col` defaults to `time` when omitted |
-| `$__timeFrom`, `$__timeFrom()` | the panel range start as an epoch integer |
-| `$__timeTo`, `$__timeTo()` | the panel range end as an epoch integer |
+| `$__timeFrom`, `$__timeFrom()` | the panel range start as an ISO 8601 UTC timestamp literal |
+| `$__timeTo`, `$__timeTo()` | the panel range end as an ISO 8601 UTC timestamp literal |
+
+The macros expand to ISO 8601 timestamp literals (e.g. `2020-09-13T12:26:40.000+00:00`), which the server interprets in its own configured `timestamp_precision` — so time filtering works unchanged on `ms`, `us` and `ns` servers, and TIMESTAMP values are likewise converted by the client using the server-reported precision.
 
 FORMAT option:
 
 * `Time series` (default): rows are sorted by the first TIMESTAMP column, and a result that contains tag/string columns next to numeric columns is pivoted into one series per tag combination — so a query returning several devices renders as separate lines in a time-series panel. Note that the pivot requires timestamps without nulls; results are sorted by the plugin, so an `ORDER BY` clause is not needed.
 * `Table`: rows are returned exactly as the server sent them (use this with the table panel, or when your `ORDER BY` should be preserved).
 
-Result columns are typed from the response's `data_types`: TIMESTAMP columns become Grafana time fields, INT32/INT64 become integers, FLOAT/DOUBLE become floats, BOOLEAN becomes booleans, and TEXT/STRING/DATE/BLOB render as strings.
+Result columns are typed from the result set's data types: TIMESTAMP columns become Grafana time fields, INT32/INT64 become integers, FLOAT/DOUBLE become floats, BOOLEAN becomes booleans, and TEXT/STRING/DATE/BLOB render as strings.
 
-If the server runs with a non-default `timestamp_precision` (`us` or `ns`), set the same value in the data source's `time precision` option — it controls both how TIMESTAMP values are interpreted and what the time macros expand to.
-
-The REST service caps query results at `rest_query_default_row_size_limit` rows (10000 by default, configurable on the server); a query exceeding it returns an error message rather than truncated data.
+There is no server-imposed row cap on this path; add a `LIMIT` clause when querying wide time ranges over dense data to bound the result size.
 
 #### Support for variables and template functions
 

--- a/connectors/grafana-plugin/README.md
+++ b/connectors/grafana-plugin/README.md
@@ -129,7 +129,7 @@ SELECT time, device_id, temperature FROM table1 WHERE $__timeFilter(time)
 
 Unlike the tree-model modes, which go through the REST service, this mode connects to the IoTDB RPC port (6667 by default). The data source's `rpc address` option sets that endpoint explicitly; when it is left empty, the URL's host with port 6667 is used.
 
-DATABASE input box: the database to run the statement against. Optional when every table reference in the statement is fully qualified (`database.table`).
+DATABASE input box: the database to run the statement against. Required — every query first runs `USE <database>` on its pooled session, so results stay deterministic regardless of which session the pool hands out. Fully-qualified `database.table` references are still allowed and take precedence over the session database.
 
 SQL input box: a single table-model SELECT statement. The following macros are expanded by the plugin before the statement is sent:
 

--- a/connectors/grafana-plugin/go.mod
+++ b/connectors/grafana-plugin/go.mod
@@ -19,11 +19,15 @@ go 1.21
 
 toolchain go1.21.0
 
-require github.com/grafana/grafana-plugin-sdk-go v0.250.0
+require (
+	github.com/apache/iotdb-client-go/v2 v2.0.8
+	github.com/grafana/grafana-plugin-sdk-go v0.250.0
+)
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+	github.com/apache/thrift v0.17.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/connectors/grafana-plugin/pkg/plugin/plugin.go
+++ b/connectors/grafana-plugin/pkg/plugin/plugin.go
@@ -227,6 +227,13 @@ func verifyQuery(query backend.DataQuery) (qp *queryParam, errMsg string) {
 		if strings.TrimSpace(qp.Sql) == "" {
 			return nil, "Input error, SQL is required"
 		}
+		// The database is required: every query then USEs it on its pooled
+		// session, so a session's leftover USE state from a previous query
+		// can never influence the result (PooledTableSession.Close only
+		// resets the database when the pool has one configured).
+		if strings.TrimSpace(qp.Database) == "" {
+			return nil, "Input error, DATABASE is required"
+		}
 	} else {
 		return nil, "none"
 	}

--- a/connectors/grafana-plugin/pkg/plugin/plugin.go
+++ b/connectors/grafana-plugin/pkg/plugin/plugin.go
@@ -70,16 +70,17 @@ func ApacheIoTDBDatasource(ctx context.Context, d backend.DataSourceInstanceSett
 	if password, exists := d.DecryptedSecureJSONData["password"]; exists {
 		authorization = "Basic " + base64.StdEncoding.EncodeToString([]byte(dm.Username+":"+password))
 	}
-	return &IoTDBDataSource{CallResourceHandler: iotdbResourceHandler(authorization, httpClient), Username: dm.Username, Ulr: dm.Url, httpClient: httpClient}, nil
+	return &IoTDBDataSource{CallResourceHandler: iotdbResourceHandler(authorization, httpClient), Username: dm.Username, Ulr: dm.Url, TimestampPrecision: dm.TimestampPrecision, httpClient: httpClient}, nil
 }
 
 // SampleDatasource is an example datasource which can respond to data queries, reports
 // its health and has streaming skills.
 type IoTDBDataSource struct {
 	backend.CallResourceHandler
-	Username   string
-	Ulr        string
-	httpClient *http.Client
+	Username           string
+	Ulr                string
+	TimestampPrecision string
+	httpClient         *http.Client
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance
@@ -113,6 +114,9 @@ func (d *IoTDBDataSource) QueryData(ctx context.Context, req *backend.QueryDataR
 type dataSourceModel struct {
 	Username string `json:"username"`
 	Url      string `json:"url"`
+	// TimestampPrecision mirrors the server's timestamp_precision property
+	// (ms, us or ns; ms when unset). Used by the table-model mode.
+	TimestampPrecision string `json:"timestampPrecision"`
 }
 
 type groupBy struct {
@@ -134,6 +138,9 @@ type queryParam struct {
 	FillClauses  string   `json:"fillClauses"`
 	GroupBy      groupBy  `json:"groupBy"`
 	Hide         bool     `json:"hide"`
+	Database     string   `json:"database"`
+	Sql          string   `json:"sql"`
+	Format       string   `json:"format"`
 }
 
 type QueryDataReq struct {
@@ -200,6 +207,10 @@ func verifyQuery(query backend.DataQuery) (qp *queryParam, errMsg string) {
 				return nil, "Input error, FROM is required"
 			}
 		}
+	} else if qp.SqlType == TableModelSqlType {
+		if strings.TrimSpace(qp.Sql) == "" {
+			return nil, "Input error, SQL is required"
+		}
 	} else {
 		return nil, "none"
 	}
@@ -230,6 +241,10 @@ func (d *IoTDBDataSource) query(cxt context.Context, pCtx backend.PluginContext,
 
 	qp.StartTime = query.TimeRange.From.UnixNano() / 1000000
 	qp.EndTime = query.TimeRange.To.UnixNano() / 1000000
+
+	if qp.SqlType == TableModelSqlType {
+		return d.queryTableModel(cxt, qp, authorization)
+	}
 
 	if qp.SqlType == "SQL: Drop-down List" {
 		qp.Control = ""

--- a/connectors/grafana-plugin/pkg/plugin/plugin.go
+++ b/connectors/grafana-plugin/pkg/plugin/plugin.go
@@ -28,8 +28,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/apache/iotdb-client-go/v2/client"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -70,17 +72,24 @@ func ApacheIoTDBDatasource(ctx context.Context, d backend.DataSourceInstanceSett
 	if password, exists := d.DecryptedSecureJSONData["password"]; exists {
 		authorization = "Basic " + base64.StdEncoding.EncodeToString([]byte(dm.Username+":"+password))
 	}
-	return &IoTDBDataSource{CallResourceHandler: iotdbResourceHandler(authorization, httpClient), Username: dm.Username, Ulr: dm.Url, TimestampPrecision: dm.TimestampPrecision, httpClient: httpClient}, nil
+	password := d.DecryptedSecureJSONData["password"]
+	return &IoTDBDataSource{CallResourceHandler: iotdbResourceHandler(authorization, httpClient), Username: dm.Username, Ulr: dm.Url, RPCAddress: dm.RPCAddress, password: password, httpClient: httpClient}, nil
 }
 
 // SampleDatasource is an example datasource which can respond to data queries, reports
 // its health and has streaming skills.
 type IoTDBDataSource struct {
 	backend.CallResourceHandler
-	Username           string
-	Ulr                string
-	TimestampPrecision string
-	httpClient         *http.Client
+	Username   string
+	Ulr        string
+	RPCAddress string
+	password   string
+	httpClient *http.Client
+
+	// Native-client session pool for the table-model mode, created lazily by
+	// getTablePool on the first table query.
+	tablePoolMu sync.Mutex
+	tablePool   *client.TableSessionPool
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance
@@ -89,6 +98,12 @@ type IoTDBDataSource struct {
 func (d *IoTDBDataSource) Dispose() {
 	// Clean up datasource instance resources.
 	d.httpClient.CloseIdleConnections()
+	d.tablePoolMu.Lock()
+	defer d.tablePoolMu.Unlock()
+	if d.tablePool != nil {
+		d.tablePool.Close()
+		d.tablePool = nil
+	}
 }
 
 // QueryData handles multiple queries and returns multiple responses.
@@ -114,9 +129,10 @@ func (d *IoTDBDataSource) QueryData(ctx context.Context, req *backend.QueryDataR
 type dataSourceModel struct {
 	Username string `json:"username"`
 	Url      string `json:"url"`
-	// TimestampPrecision mirrors the server's timestamp_precision property
-	// (ms, us or ns; ms when unset). Used by the table-model mode.
-	TimestampPrecision string `json:"timestampPrecision"`
+	// RPCAddress is the IoTDB RPC endpoint (host or host:port) the native
+	// client used by the table-model mode connects to. When empty, the URL's
+	// host with the default RPC port 6667 is used.
+	RPCAddress string `json:"rpcAddress"`
 }
 
 type groupBy struct {
@@ -243,7 +259,7 @@ func (d *IoTDBDataSource) query(cxt context.Context, pCtx backend.PluginContext,
 	qp.EndTime = query.TimeRange.To.UnixNano() / 1000000
 
 	if qp.SqlType == TableModelSqlType {
-		return d.queryTableModel(cxt, qp, authorization)
+		return d.queryTableModel(cxt, qp)
 	}
 
 	if qp.SqlType == "SQL: Drop-down List" {

--- a/connectors/grafana-plugin/pkg/plugin/table_query.go
+++ b/connectors/grafana-plugin/pkg/plugin/table_query.go
@@ -18,26 +18,28 @@
 package plugin
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
+	"encoding/hex"
 	"errors"
-	"io"
-	"net/http"
+	"fmt"
+	"net"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/apache/iotdb-client-go/v2/client"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-// TableModelSqlType is the QueryEditor mode that sends standard table-model SQL
-// straight to IoTDB's table REST interface, as opposed to the tree-model modes
-// ("SQL: Full Customized" / "SQL: Drop-down List") that build root.* paths.
+// TableModelSqlType is the QueryEditor mode that runs standard table-model SQL
+// through the native Go client (apache/iotdb-client-go), as opposed to the
+// tree-model modes ("SQL: Full Customized" / "SQL: Drop-down List") that build
+// root.* paths and go through the REST /grafana endpoints.
 const TableModelSqlType = "SQL: Table Model"
 
 // Result formats for the table-model mode. Time series (the default) sorts
@@ -49,31 +51,17 @@ const (
 	tableFormatTable      = "Table"
 )
 
-// tableQueryPath is IoTDB's table-model query endpoint (see the /rest/table/v1
-// RestApi). It accepts a standard SQL statement plus an optional database
-// context and returns a column-major QueryDataSet.
-const tableQueryPath = "/rest/table/v1/query"
-
-// tableQueryReq is the request body for tableQueryPath. Field names match the
-// generated table/v1 SQL model (database / sql / row_limit).
-type tableQueryReq struct {
-	Database string `json:"database,omitempty"`
-	Sql      string `json:"sql"`
-	RowLimit *int   `json:"row_limit,omitempty"`
-}
-
-// tableQueryDataSet mirrors the table/v1 QueryDataSet response. Its values are
-// ROW-major (values[row][col]) because the table endpoint transposes before
-// serializing, unlike the tree-model endpoints. snake_case JSON. On failure
-// IoTDB returns an ExecutionStatus instead, whose code/message are captured
-// here so a non-zero code surfaces as an error.
-type tableQueryDataSet struct {
-	ColumnNames []string        `json:"column_names"`
-	DataTypes   []string        `json:"data_types"`
-	Values      [][]interface{} `json:"values"`
-	Code        int32           `json:"code"`
-	Message     string          `json:"message"`
-}
+// Connection settings for the native client. The RPC endpoint is the
+// datasource's "rpc address" option, or the URL's host with the default RPC
+// port when unset. The pool is created lazily on the first table-model query
+// so datasources that only use the tree model never open an RPC connection.
+const (
+	defaultRPCPort            = "6667"
+	tablePoolMaxSize          = 8
+	tableConnectTimeoutMs     = 10000
+	tableWaitSessionTimeoutMs = 60000
+	defaultQueryTimeoutMs     = int64(60000)
+)
 
 // timeFilterRe matches Grafana's $__timeFilter(column) macro; the column is
 // optional and defaults to "time". One level of nested parentheses is allowed
@@ -87,19 +75,13 @@ var (
 	timeToRe   = regexp.MustCompile(`\$__timeTo\b(?:\s*\(\s*\))?`)
 )
 
-// timestampUnits maps the datasource's timestampPrecision option (which must
-// match the server's timestamp_precision property) to conversion factors:
-// unitsPerMs scales the panel's epoch-ms range into server units for the time
-// macros, nsPerUnit scales raw TIMESTAMP values into nanoseconds for Grafana.
-func timestampUnits(precision string) (unitsPerMs int64, nsPerUnit int64) {
-	switch strings.TrimSpace(strings.ToLower(precision)) {
-	case "us":
-		return 1000, int64(time.Microsecond)
-	case "ns":
-		return 1000000, 1
-	default: // ms is IoTDB's default timestamp_precision
-		return 1, int64(time.Millisecond)
-	}
+// formatTimeLiteral renders a panel-range bound as an ISO 8601 UTC timestamp
+// literal (e.g. 2020-09-13T12:26:40.000+00:00). The server parses such a
+// literal in its own configured timestamp precision, so the expansion works
+// unchanged on ms, us and ns servers — unlike a bare epoch integer, which the
+// server would interpret in raw server units.
+func formatTimeLiteral(ms int64) string {
+	return time.UnixMilli(ms).UTC().Format("2006-01-02T15:04:05.000") + "+00:00"
 }
 
 // expandTableMacros rewrites the Grafana time macros a dashboard author can put
@@ -109,12 +91,11 @@ func timestampUnits(precision string) (unitsPerMs int64, nsPerUnit int64) {
 //	$__timeFrom[()]         -> <from>
 //	$__timeTo[()]           -> <to>
 //
-// Bounds are epoch values in the server's timestamp precision (milliseconds
-// unless the datasource says otherwise), matching how IoTDB compares integer
-// literals against TIMESTAMP columns.
-func expandTableMacros(sql string, start int64, end int64) string {
-	from := strconv.FormatInt(start, 10)
-	to := strconv.FormatInt(end, 10)
+// Bounds are ISO 8601 UTC timestamp literals, which IoTDB compares against
+// TIMESTAMP columns independently of the server's timestamp precision.
+func expandTableMacros(sql string, startMs int64, endMs int64) string {
+	from := formatTimeLiteral(startMs)
+	to := formatTimeLiteral(endMs)
 	sql = timeFilterRe.ReplaceAllStringFunc(sql, func(m string) string {
 		col := strings.TrimSpace(timeFilterRe.FindStringSubmatch(m)[1])
 		if col == "" {
@@ -127,64 +108,167 @@ func expandTableMacros(sql string, start int64, end int64) string {
 	return sql
 }
 
-// queryTableModel runs a table-model SQL query against IoTDB's table REST
-// endpoint and turns the column-major QueryDataSet into a Grafana data frame.
-func (d *IoTDBDataSource) queryTableModel(ctx context.Context, qp *queryParam, authorization string) backend.DataResponse {
+// quoteTableIdentifier wraps a table-model identifier in double quotes
+// (doubling any embedded quote), the relational grammar's quoted-identifier
+// form, so a database name survives the USE statement verbatim.
+func quoteTableIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// tableQueryDataSet is the plugin-internal carrier for a fetched table-model
+// result: column names and IoTDB type names as reported by the client, plus
+// row-major cell values (values[row][col]) holding the client's native Go
+// representations (time.Time for TIMESTAMP/DATE, string for TEXT/STRING,
+// []byte for BLOB, bool/int32/int64/float32/float64 for the scalars, nil for
+// null).
+type tableQueryDataSet struct {
+	ColumnNames []string
+	DataTypes   []string
+	Values      [][]interface{}
+}
+
+// tableResultSet is the slice of the native client's SessionDataSet the fetch
+// path needs; narrowing it to an interface keeps fetchTableDataSet testable
+// without a live server. Column indexes are 1-based, matching the client.
+type tableResultSet interface {
+	Next() (bool, error)
+	GetColumnNames() []string
+	GetColumnTypes() []string
+	GetObjectByIndex(columnIndex int32) (interface{}, error)
+	Close() error
+}
+
+// fetchTableDataSet drains a result set into a tableQueryDataSet. The caller
+// owns closing the result set.
+func fetchTableDataSet(rs tableResultSet) (*tableQueryDataSet, error) {
+	names := rs.GetColumnNames()
+	types := rs.GetColumnTypes()
+	dataSet := &tableQueryDataSet{ColumnNames: names, DataTypes: types, Values: [][]interface{}{}}
+	for {
+		hasNext, err := rs.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !hasNext {
+			return dataSet, nil
+		}
+		row := make([]interface{}, len(names))
+		for i := range names {
+			value, err := rs.GetObjectByIndex(int32(i) + 1)
+			if err != nil {
+				return nil, err
+			}
+			row[i] = value
+		}
+		dataSet.Values = append(dataSet.Values, row)
+	}
+}
+
+// tableRPCEndpoint resolves the host and port of the IoTDB RPC service the
+// native client connects to: the datasource's "rpc address" option when set
+// (host or host:port), otherwise the datasource URL's host with the default
+// RPC port.
+func (d *IoTDBDataSource) tableRPCEndpoint() (string, string, error) {
+	if addr := strings.TrimSpace(d.RPCAddress); addr != "" {
+		if host, port, err := net.SplitHostPort(addr); err == nil {
+			return host, port, nil
+		}
+		return strings.Trim(addr, "[]"), defaultRPCPort, nil
+	}
+	raw := strings.TrimSpace(d.Ulr)
+	if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+		return u.Hostname(), defaultRPCPort, nil
+	}
+	// A bare host[:restPort] without a scheme parses as opaque; retry with one.
+	if u, err := url.Parse("http://" + raw); err == nil && u.Hostname() != "" {
+		return u.Hostname(), defaultRPCPort, nil
+	}
+	return "", "", errors.New("cannot derive the IoTDB RPC host from the datasource URL; please set the rpc address option")
+}
+
+// getTablePool lazily creates the shared native-client session pool for this
+// datasource instance. Pool construction does not connect; connection errors
+// surface on GetSession.
+func (d *IoTDBDataSource) getTablePool() (*client.TableSessionPool, error) {
+	d.tablePoolMu.Lock()
+	defer d.tablePoolMu.Unlock()
+	if d.tablePool != nil {
+		return d.tablePool, nil
+	}
+	host, port, err := d.tableRPCEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	poolConfig := &client.PoolConfig{
+		Host:     host,
+		Port:     port,
+		UserName: d.Username,
+		Password: d.password,
+	}
+	pool := client.NewTableSessionPool(poolConfig, tablePoolMaxSize, tableConnectTimeoutMs, tableWaitSessionTimeoutMs, false)
+	d.tablePool = &pool
+	return d.tablePool, nil
+}
+
+// queryTableModel runs a table-model SQL query through the native client and
+// turns the result set into a Grafana data frame.
+func (d *IoTDBDataSource) queryTableModel(ctx context.Context, qp *queryParam) backend.DataResponse {
 	response := backend.DataResponse{}
 
-	// The panel range arrives in epoch ms; the server compares integer time
-	// literals (and returns TIMESTAMP values) in its own configured precision.
-	unitsPerMs, nsPerUnit := timestampUnits(d.TimestampPrecision)
+	sql := expandTableMacros(qp.Sql, qp.StartTime, qp.EndTime)
 
-	sql := expandTableMacros(qp.Sql, qp.StartTime*unitsPerMs, qp.EndTime*unitsPerMs)
-	reqBody := tableQueryReq{Database: qp.Database, Sql: sql}
-	qpJson, err := json.Marshal(reqBody)
+	pool, err := d.getTablePool()
+	if err != nil {
+		response.Error = err
+		return response
+	}
+	session, err := pool.GetSession()
+	if err != nil {
+		response.Error = fmt.Errorf("cannot connect to the IoTDB RPC service: %w", err)
+		log.DefaultLogger.Error("Cannot connect to the IoTDB RPC service", "err", err)
+		return response
+	}
+	defer func() {
+		if closeErr := session.Close(); closeErr != nil {
+			log.DefaultLogger.Error("Failed to return session to the pool", "err", closeErr)
+		}
+	}()
+
+	if database := strings.TrimSpace(qp.Database); database != "" {
+		if err := session.ExecuteNonQueryStatement("USE " + quoteTableIdentifier(database)); err != nil {
+			response.Error = err
+			return response
+		}
+	}
+
+	timeout := defaultQueryTimeoutMs
+	if deadline, ok := ctx.Deadline(); ok {
+		if ms := time.Until(deadline).Milliseconds(); ms > 0 {
+			timeout = ms
+		}
+	}
+	resultSet, err := session.ExecuteQueryStatement(sql, &timeout)
+	if err != nil {
+		response.Error = err
+		return response
+	}
+	defer func() {
+		if closeErr := resultSet.Close(); closeErr != nil {
+			log.DefaultLogger.Error("Failed to close the result set", "err", closeErr)
+		}
+	}()
+
+	dataSet, err := fetchTableDataSet(resultSet)
 	if err != nil {
 		response.Error = err
 		return response
 	}
 
-	dataSourceUrl := DataSourceUrlHandler(d.Ulr)
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, dataSourceUrl+tableQueryPath, bytes.NewReader(qpJson))
-	if err != nil {
-		response.Error = err
-		return response
-	}
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Add("Authorization", authorization)
-
-	rsp, err := d.httpClient.Do(request)
-	if err != nil {
-		response.Error = errors.New("Data source is not working properly")
-		log.DefaultLogger.Error("Data source is not working properly", "err", err)
-		return response
-	}
-	defer rsp.Body.Close()
-
-	body, err := io.ReadAll(rsp.Body)
-	if err != nil {
-		response.Error = errors.New("Data source is not working properly")
-		log.DefaultLogger.Error("Failed to read response body", "err", err)
-		return response
-	}
-
-	dataSet, err := parseTableQueryResponse(body)
-	if err != nil {
-		response.Error = err
-		log.DefaultLogger.Error("Parsing JSON error", "err", err)
-		return response
-	}
-	if dataSet.Code > 0 {
-		response.Error = errors.New(dataSet.Message)
-		log.DefaultLogger.Error(dataSet.Message)
-		return response
-	}
-
-	response.Frames = append(response.Frames, buildTableResponseFrame(dataSet, qp.Format, nsPerUnit))
+	response.Frames = append(response.Frames, buildTableResponseFrame(dataSet, qp.Format))
 	return response
 }
 
-// buildTableResponseFrame turns a decoded dataset into the response frame,
+// buildTableResponseFrame turns a fetched dataset into the response frame,
 // honoring the query's format. In the default Time series format the rows are
 // sorted ascending by the first TIMESTAMP column and a long-shaped result
 // (time + string tag columns + value columns) is pivoted into one labeled
@@ -192,14 +276,14 @@ func (d *IoTDBDataSource) queryTableModel(ctx context.Context, qp *queryParam, a
 // lines instead of one interleaved series; when the pivot does not apply (or
 // fails, e.g. on a null timestamp) the plain frame is returned. The Table
 // format preserves the server's row order untouched.
-func buildTableResponseFrame(dataSet *tableQueryDataSet, format string, nsPerUnit int64) *data.Frame {
+func buildTableResponseFrame(dataSet *tableQueryDataSet, format string) *data.Frame {
 	// Anything that is not explicitly the Table format gets the default
 	// time-series treatment, including queries saved before FORMAT existed.
 	isTimeSeries := !strings.EqualFold(format, tableFormatTable)
 	if isTimeSeries {
 		sortRowsByFirstTimestamp(dataSet)
 	}
-	frame := buildTableFrame(dataSet, nsPerUnit)
+	frame := buildTableFrame(dataSet)
 	if isTimeSeries && frame.TimeSeriesSchema().Type == data.TimeSeriesTypeLong {
 		if wide, err := data.LongToWide(frame, nil); err == nil {
 			frame = wide
@@ -228,38 +312,23 @@ func sortRowsByFirstTimestamp(dataSet *tableQueryDataSet) {
 		if okA != okB {
 			return okA
 		}
-		return okA && va < vb
+		return okA && va.Before(vb)
 	})
 }
 
-func rowTimeAt(row []interface{}, col int) (int64, bool) {
+func rowTimeAt(row []interface{}, col int) (time.Time, bool) {
 	if col >= len(row) {
-		return 0, false
+		return time.Time{}, false
 	}
-	return toInt64(row[col])
+	t, ok := row[col].(time.Time)
+	return t, ok
 }
 
-// parseTableQueryResponse unmarshals a table-model query response, surfacing an
-// error object (code/message) as a Go error when the request did not succeed.
-// It decodes with UseNumber so that INT64/TIMESTAMP values beyond 2^53 keep
-// their precision (a plain interface{} decode would coerce them to float64).
-func parseTableQueryResponse(body []byte) (*tableQueryDataSet, error) {
-	var dataSet tableQueryDataSet
-	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.UseNumber()
-	if err := decoder.Decode(&dataSet); err != nil {
-		return nil, errors.New("Parsing JSON error")
-	}
-	return &dataSet, nil
-}
-
-// buildTableFrame converts a row-major QueryDataSet into a Grafana frame, one
-// typed field per column driven by the response's data_types (so we no longer
-// have to guess types the way the tree-model path does). The endpoint returns
-// values row-major (values[row][col]); each output field gathers a single
-// column across all rows, so every field ends up the same length (the row
-// count) that Grafana requires.
-func buildTableFrame(dataSet *tableQueryDataSet, nsPerUnit int64) *data.Frame {
+// buildTableFrame converts the row-major dataset into a Grafana frame, one
+// typed field per column driven by the reported data types; each field gathers
+// a single column across all rows, so every field ends up the same length (the
+// row count) that Grafana requires.
+func buildTableFrame(dataSet *tableQueryDataSet) *data.Frame {
 	frame := data.NewFrame("response")
 	rowCount := len(dataSet.Values)
 	for col := 0; col < len(dataSet.ColumnNames); col++ {
@@ -274,24 +343,25 @@ func buildTableFrame(dataSet *tableQueryDataSet, nsPerUnit int64) *data.Frame {
 				columnValues[row] = dataSet.Values[row][col]
 			}
 		}
-		frame.Fields = append(frame.Fields, buildTableField(name, dataType, columnValues, nsPerUnit))
+		frame.Fields = append(frame.Fields, buildTableField(name, dataType, columnValues))
 	}
 	return frame
 }
 
-// buildTableField turns one column's raw JSON values into a typed, nullable
-// Grafana field selected by the IoTDB data type. Numbers arrive as json.Number
-// (the body is decoded with UseNumber), so integer, timestamp and float columns
-// are coerced through toInt64 / toFloat64. TIMESTAMP values are raw epoch
-// ticks in the server's precision; nsPerUnit scales them to nanoseconds.
-func buildTableField(name string, dataType string, values []interface{}, nsPerUnit int64) *data.Field {
+// buildTableField turns one column's native client values into a typed,
+// nullable Grafana field selected by the IoTDB data type. The client already
+// converts TIMESTAMP (and DATE) values to time.Time using the server-reported
+// timestamp precision, so no unit handling happens here. DATE and BLOB render
+// as strings (yyyy-MM-dd and 0x-prefixed hex), matching the REST behavior the
+// mode previously had.
+func buildTableField(name string, dataType string, values []interface{}) *data.Field {
 	switch strings.ToUpper(dataType) {
 	case "TIMESTAMP":
 		out := make([]*time.Time, len(values))
 		for i, v := range values {
-			if ticks, ok := toInt64(v); ok {
-				t := time.Unix(0, ticks*nsPerUnit)
-				out[i] = &t
+			if t, ok := v.(time.Time); ok {
+				value := t
+				out[i] = &value
 			}
 		}
 		return data.NewField(name, nil, out)
@@ -322,75 +392,83 @@ func buildTableField(name string, dataType string, values []interface{}, nsPerUn
 			}
 		}
 		return data.NewField(name, nil, out)
+	case "DATE":
+		out := make([]*string, len(values))
+		for i, v := range values {
+			if t, ok := v.(time.Time); ok {
+				value := t.Format("2006-01-02")
+				out[i] = &value
+			}
+		}
+		return data.NewField(name, nil, out)
+	case "BLOB":
+		out := make([]*string, len(values))
+		for i, v := range values {
+			if b, ok := v.([]byte); ok {
+				value := "0x" + hex.EncodeToString(b)
+				out[i] = &value
+			}
+		}
+		return data.NewField(name, nil, out)
 	default:
-		// TEXT, STRING, BLOB and anything unrecognised render as strings.
+		// TEXT, STRING and anything unrecognised render as strings.
 		out := make([]*string, len(values))
 		for i, v := range values {
 			if v == nil {
 				continue
 			}
-			if s, ok := v.(string); ok {
-				value := s
-				out[i] = &value
-			} else {
-				value := toString(v)
-				out[i] = &value
-			}
+			value := toString(v)
+			out[i] = &value
 		}
 		return data.NewField(name, nil, out)
 	}
 }
 
-// toInt64 coerces a JSON-decoded numeric value to int64. encoding/json decodes
-// numbers into float64 by default; json.Number is handled too for callers that
-// opt into it.
+// toInt64 coerces the client's integer representations (INT32 -> int32,
+// INT64 -> int64) to int64.
 func toInt64(v interface{}) (int64, bool) {
 	switch n := v.(type) {
-	case float64:
-		return int64(n), true
-	case json.Number:
-		if i, err := n.Int64(); err == nil {
-			return i, true
-		}
-		if f, err := n.Float64(); err == nil {
-			return int64(f), true
-		}
 	case int64:
 		return n, true
+	case int32:
+		return int64(n), true
 	}
 	return 0, false
 }
 
-// toFloat64 coerces a JSON-decoded numeric value to float64, handling both the
-// float64 (plain decode) and json.Number (UseNumber decode) representations.
+// toFloat64 coerces the client's floating representations (FLOAT -> float32,
+// DOUBLE -> float64) to float64.
 func toFloat64(v interface{}) (float64, bool) {
 	switch n := v.(type) {
 	case float64:
 		return n, true
-	case json.Number:
-		if f, err := n.Float64(); err == nil {
-			return f, true
-		}
+	case float32:
+		return float64(n), true
 	}
 	return 0, false
 }
 
-// toString renders a non-string scalar for a text column without losing it.
+// toString renders a value for a text column without losing it, whatever the
+// client handed over.
 func toString(v interface{}) string {
 	switch value := v.(type) {
 	case string:
 		return value
-	case float64:
-		return strconv.FormatFloat(value, 'f', -1, 64)
+	case []byte:
+		return "0x" + hex.EncodeToString(value)
+	case time.Time:
+		return value.UTC().Format(time.RFC3339Nano)
 	case bool:
 		return strconv.FormatBool(value)
-	case json.Number:
-		return value.String()
+	case int32:
+		return strconv.FormatInt(int64(value), 10)
+	case int64:
+		return strconv.FormatInt(value, 10)
+	case float32:
+		return strconv.FormatFloat(float64(value), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
 	default:
-		b, err := json.Marshal(v)
-		if err != nil {
-			return ""
-		}
-		return string(b)
+		return fmt.Sprintf("%v", v)
 	}
 }

--- a/connectors/grafana-plugin/pkg/plugin/table_query.go
+++ b/connectors/grafana-plugin/pkg/plugin/table_query.go
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// TableModelSqlType is the QueryEditor mode that sends standard table-model SQL
+// straight to IoTDB's table REST interface, as opposed to the tree-model modes
+// ("SQL: Full Customized" / "SQL: Drop-down List") that build root.* paths.
+const TableModelSqlType = "SQL: Table Model"
+
+// Result formats for the table-model mode. Time series (the default) sorts
+// rows ascending by the first TIMESTAMP column and pivots a long-shaped result
+// (time + tag columns + value columns) into one labeled series per tag
+// combination; Table returns the rows exactly as the server sent them.
+const (
+	tableFormatTimeSeries = "Time series"
+	tableFormatTable      = "Table"
+)
+
+// tableQueryPath is IoTDB's table-model query endpoint (see the /rest/table/v1
+// RestApi). It accepts a standard SQL statement plus an optional database
+// context and returns a column-major QueryDataSet.
+const tableQueryPath = "/rest/table/v1/query"
+
+// tableQueryReq is the request body for tableQueryPath. Field names match the
+// generated table/v1 SQL model (database / sql / row_limit).
+type tableQueryReq struct {
+	Database string `json:"database,omitempty"`
+	Sql      string `json:"sql"`
+	RowLimit *int   `json:"row_limit,omitempty"`
+}
+
+// tableQueryDataSet mirrors the table/v1 QueryDataSet response. Its values are
+// ROW-major (values[row][col]) because the table endpoint transposes before
+// serializing, unlike the tree-model endpoints. snake_case JSON. On failure
+// IoTDB returns an ExecutionStatus instead, whose code/message are captured
+// here so a non-zero code surfaces as an error.
+type tableQueryDataSet struct {
+	ColumnNames []string        `json:"column_names"`
+	DataTypes   []string        `json:"data_types"`
+	Values      [][]interface{} `json:"values"`
+	Code        int32           `json:"code"`
+	Message     string          `json:"message"`
+}
+
+// timeFilterRe matches Grafana's $__timeFilter(column) macro; the column is
+// optional and defaults to "time". One level of nested parentheses is allowed
+// so expressions like $__timeFilter(cast(x)) survive intact.
+var timeFilterRe = regexp.MustCompile(`\$__timeFilter\(\s*((?:[^()]|\([^()]*\))*?)\s*\)`)
+
+// timeFromRe / timeToRe match $__timeFrom / $__timeTo, with or without the
+// trailing () that Grafana's SQL data sources use ($__timeFrom()).
+var (
+	timeFromRe = regexp.MustCompile(`\$__timeFrom\b(?:\s*\(\s*\))?`)
+	timeToRe   = regexp.MustCompile(`\$__timeTo\b(?:\s*\(\s*\))?`)
+)
+
+// timestampUnits maps the datasource's timestampPrecision option (which must
+// match the server's timestamp_precision property) to conversion factors:
+// unitsPerMs scales the panel's epoch-ms range into server units for the time
+// macros, nsPerUnit scales raw TIMESTAMP values into nanoseconds for Grafana.
+func timestampUnits(precision string) (unitsPerMs int64, nsPerUnit int64) {
+	switch strings.TrimSpace(strings.ToLower(precision)) {
+	case "us":
+		return 1000, int64(time.Microsecond)
+	case "ns":
+		return 1000000, 1
+	default: // ms is IoTDB's default timestamp_precision
+		return 1, int64(time.Millisecond)
+	}
+}
+
+// expandTableMacros rewrites the Grafana time macros a dashboard author can put
+// in table-model SQL into concrete bounds for the panel's range:
+//
+//	$__timeFilter(col)      -> (col >= <from> AND col <= <to>)
+//	$__timeFrom[()]         -> <from>
+//	$__timeTo[()]           -> <to>
+//
+// Bounds are epoch values in the server's timestamp precision (milliseconds
+// unless the datasource says otherwise), matching how IoTDB compares integer
+// literals against TIMESTAMP columns.
+func expandTableMacros(sql string, start int64, end int64) string {
+	from := strconv.FormatInt(start, 10)
+	to := strconv.FormatInt(end, 10)
+	sql = timeFilterRe.ReplaceAllStringFunc(sql, func(m string) string {
+		col := strings.TrimSpace(timeFilterRe.FindStringSubmatch(m)[1])
+		if col == "" {
+			col = "time"
+		}
+		return "(" + col + " >= " + from + " AND " + col + " <= " + to + ")"
+	})
+	sql = timeFromRe.ReplaceAllString(sql, from)
+	sql = timeToRe.ReplaceAllString(sql, to)
+	return sql
+}
+
+// queryTableModel runs a table-model SQL query against IoTDB's table REST
+// endpoint and turns the column-major QueryDataSet into a Grafana data frame.
+func (d *IoTDBDataSource) queryTableModel(ctx context.Context, qp *queryParam, authorization string) backend.DataResponse {
+	response := backend.DataResponse{}
+
+	// The panel range arrives in epoch ms; the server compares integer time
+	// literals (and returns TIMESTAMP values) in its own configured precision.
+	unitsPerMs, nsPerUnit := timestampUnits(d.TimestampPrecision)
+
+	sql := expandTableMacros(qp.Sql, qp.StartTime*unitsPerMs, qp.EndTime*unitsPerMs)
+	reqBody := tableQueryReq{Database: qp.Database, Sql: sql}
+	qpJson, err := json.Marshal(reqBody)
+	if err != nil {
+		response.Error = err
+		return response
+	}
+
+	dataSourceUrl := DataSourceUrlHandler(d.Ulr)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, dataSourceUrl+tableQueryPath, bytes.NewReader(qpJson))
+	if err != nil {
+		response.Error = err
+		return response
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Add("Authorization", authorization)
+
+	rsp, err := d.httpClient.Do(request)
+	if err != nil {
+		response.Error = errors.New("Data source is not working properly")
+		log.DefaultLogger.Error("Data source is not working properly", "err", err)
+		return response
+	}
+	defer rsp.Body.Close()
+
+	body, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		response.Error = errors.New("Data source is not working properly")
+		log.DefaultLogger.Error("Failed to read response body", "err", err)
+		return response
+	}
+
+	dataSet, err := parseTableQueryResponse(body)
+	if err != nil {
+		response.Error = err
+		log.DefaultLogger.Error("Parsing JSON error", "err", err)
+		return response
+	}
+	if dataSet.Code > 0 {
+		response.Error = errors.New(dataSet.Message)
+		log.DefaultLogger.Error(dataSet.Message)
+		return response
+	}
+
+	response.Frames = append(response.Frames, buildTableResponseFrame(dataSet, qp.Format, nsPerUnit))
+	return response
+}
+
+// buildTableResponseFrame turns a decoded dataset into the response frame,
+// honoring the query's format. In the default Time series format the rows are
+// sorted ascending by the first TIMESTAMP column and a long-shaped result
+// (time + string tag columns + value columns) is pivoted into one labeled
+// series per tag combination, so a multi-device query renders as separate
+// lines instead of one interleaved series; when the pivot does not apply (or
+// fails, e.g. on a null timestamp) the plain frame is returned. The Table
+// format preserves the server's row order untouched.
+func buildTableResponseFrame(dataSet *tableQueryDataSet, format string, nsPerUnit int64) *data.Frame {
+	// Anything that is not explicitly the Table format gets the default
+	// time-series treatment, including queries saved before FORMAT existed.
+	isTimeSeries := !strings.EqualFold(format, tableFormatTable)
+	if isTimeSeries {
+		sortRowsByFirstTimestamp(dataSet)
+	}
+	frame := buildTableFrame(dataSet, nsPerUnit)
+	if isTimeSeries && frame.TimeSeriesSchema().Type == data.TimeSeriesTypeLong {
+		if wide, err := data.LongToWide(frame, nil); err == nil {
+			frame = wide
+		}
+	}
+	return frame
+}
+
+// sortRowsByFirstTimestamp stably sorts the row-major values ascending by the
+// first TIMESTAMP column, which both time-series rendering and the long-to-wide
+// pivot require. Rows whose time cell is null sort last.
+func sortRowsByFirstTimestamp(dataSet *tableQueryDataSet) {
+	timeCol := -1
+	for i, t := range dataSet.DataTypes {
+		if strings.EqualFold(t, "TIMESTAMP") {
+			timeCol = i
+			break
+		}
+	}
+	if timeCol < 0 {
+		return
+	}
+	sort.SliceStable(dataSet.Values, func(a, b int) bool {
+		va, okA := rowTimeAt(dataSet.Values[a], timeCol)
+		vb, okB := rowTimeAt(dataSet.Values[b], timeCol)
+		if okA != okB {
+			return okA
+		}
+		return okA && va < vb
+	})
+}
+
+func rowTimeAt(row []interface{}, col int) (int64, bool) {
+	if col >= len(row) {
+		return 0, false
+	}
+	return toInt64(row[col])
+}
+
+// parseTableQueryResponse unmarshals a table-model query response, surfacing an
+// error object (code/message) as a Go error when the request did not succeed.
+// It decodes with UseNumber so that INT64/TIMESTAMP values beyond 2^53 keep
+// their precision (a plain interface{} decode would coerce them to float64).
+func parseTableQueryResponse(body []byte) (*tableQueryDataSet, error) {
+	var dataSet tableQueryDataSet
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&dataSet); err != nil {
+		return nil, errors.New("Parsing JSON error")
+	}
+	return &dataSet, nil
+}
+
+// buildTableFrame converts a row-major QueryDataSet into a Grafana frame, one
+// typed field per column driven by the response's data_types (so we no longer
+// have to guess types the way the tree-model path does). The endpoint returns
+// values row-major (values[row][col]); each output field gathers a single
+// column across all rows, so every field ends up the same length (the row
+// count) that Grafana requires.
+func buildTableFrame(dataSet *tableQueryDataSet, nsPerUnit int64) *data.Frame {
+	frame := data.NewFrame("response")
+	rowCount := len(dataSet.Values)
+	for col := 0; col < len(dataSet.ColumnNames); col++ {
+		name := dataSet.ColumnNames[col]
+		dataType := ""
+		if col < len(dataSet.DataTypes) {
+			dataType = dataSet.DataTypes[col]
+		}
+		columnValues := make([]interface{}, rowCount)
+		for row := 0; row < rowCount; row++ {
+			if col < len(dataSet.Values[row]) {
+				columnValues[row] = dataSet.Values[row][col]
+			}
+		}
+		frame.Fields = append(frame.Fields, buildTableField(name, dataType, columnValues, nsPerUnit))
+	}
+	return frame
+}
+
+// buildTableField turns one column's raw JSON values into a typed, nullable
+// Grafana field selected by the IoTDB data type. Numbers arrive as json.Number
+// (the body is decoded with UseNumber), so integer, timestamp and float columns
+// are coerced through toInt64 / toFloat64. TIMESTAMP values are raw epoch
+// ticks in the server's precision; nsPerUnit scales them to nanoseconds.
+func buildTableField(name string, dataType string, values []interface{}, nsPerUnit int64) *data.Field {
+	switch strings.ToUpper(dataType) {
+	case "TIMESTAMP":
+		out := make([]*time.Time, len(values))
+		for i, v := range values {
+			if ticks, ok := toInt64(v); ok {
+				t := time.Unix(0, ticks*nsPerUnit)
+				out[i] = &t
+			}
+		}
+		return data.NewField(name, nil, out)
+	case "INT32", "INT64":
+		out := make([]*int64, len(values))
+		for i, v := range values {
+			if n, ok := toInt64(v); ok {
+				value := n
+				out[i] = &value
+			}
+		}
+		return data.NewField(name, nil, out)
+	case "FLOAT", "DOUBLE":
+		out := make([]*float64, len(values))
+		for i, v := range values {
+			if f, ok := toFloat64(v); ok {
+				value := f
+				out[i] = &value
+			}
+		}
+		return data.NewField(name, nil, out)
+	case "BOOLEAN":
+		out := make([]*bool, len(values))
+		for i, v := range values {
+			if b, ok := v.(bool); ok {
+				value := b
+				out[i] = &value
+			}
+		}
+		return data.NewField(name, nil, out)
+	default:
+		// TEXT, STRING, BLOB and anything unrecognised render as strings.
+		out := make([]*string, len(values))
+		for i, v := range values {
+			if v == nil {
+				continue
+			}
+			if s, ok := v.(string); ok {
+				value := s
+				out[i] = &value
+			} else {
+				value := toString(v)
+				out[i] = &value
+			}
+		}
+		return data.NewField(name, nil, out)
+	}
+}
+
+// toInt64 coerces a JSON-decoded numeric value to int64. encoding/json decodes
+// numbers into float64 by default; json.Number is handled too for callers that
+// opt into it.
+func toInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i, true
+		}
+		if f, err := n.Float64(); err == nil {
+			return int64(f), true
+		}
+	case int64:
+		return n, true
+	}
+	return 0, false
+}
+
+// toFloat64 coerces a JSON-decoded numeric value to float64, handling both the
+// float64 (plain decode) and json.Number (UseNumber decode) representations.
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case json.Number:
+		if f, err := n.Float64(); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+// toString renders a non-string scalar for a text column without losing it.
+func toString(v interface{}) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(value)
+	case json.Number:
+		return value.String()
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}

--- a/connectors/grafana-plugin/pkg/plugin/table_query_test.go
+++ b/connectors/grafana-plugin/pkg/plugin/table_query_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
@@ -367,6 +368,28 @@ func TestBuildTableResponseFrameNullTimeFallsBack(t *testing.T) {
 	}
 	if frame.TimeSeriesSchema().Type != data.TimeSeriesTypeLong {
 		t.Fatalf("fallback frame should still be the long-shaped original")
+	}
+}
+
+// TestVerifyQueryTableModel pins the table-mode input validation: SQL and
+// DATABASE are both required (the latter so every query USEs its database on
+// the pooled session and leftover USE state can never leak between panels).
+func TestVerifyQueryTableModel(t *testing.T) {
+	build := func(body string) backend.DataQuery {
+		return backend.DataQuery{JSON: []byte(body)}
+	}
+
+	if _, msg := verifyQuery(build(`{"sqlType":"SQL: Table Model","sql":"SELECT 1","database":"db1"}`)); msg != "" {
+		t.Fatalf("valid table query rejected: %q", msg)
+	}
+	if _, msg := verifyQuery(build(`{"sqlType":"SQL: Table Model","sql":"  ","database":"db1"}`)); msg != "Input error, SQL is required" {
+		t.Fatalf("blank sql not rejected: %q", msg)
+	}
+	if _, msg := verifyQuery(build(`{"sqlType":"SQL: Table Model","sql":"SELECT 1","database":" "}`)); msg != "Input error, DATABASE is required" {
+		t.Fatalf("blank database not rejected: %q", msg)
+	}
+	if _, msg := verifyQuery(build(`{"sqlType":"SQL: Table Model","sql":"SELECT 1"}`)); msg != "Input error, DATABASE is required" {
+		t.Fatalf("missing database not rejected: %q", msg)
 	}
 }
 

--- a/connectors/grafana-plugin/pkg/plugin/table_query_test.go
+++ b/connectors/grafana-plugin/pkg/plugin/table_query_test.go
@@ -18,18 +18,22 @@
 package plugin
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-// msNs is the TIMESTAMP tick-to-nanosecond factor for a default (ms) server.
-const msNs = int64(time.Millisecond)
+func ts(ms int64) time.Time {
+	return time.UnixMilli(ms).UTC()
+}
 
 func TestExpandTableMacros(t *testing.T) {
-	const from int64 = 1000
-	const to int64 = 2000
+	const from int64 = 1600000000000 // 2020-09-13T12:26:40.000+00:00
+	const to int64 = 1600000001000   // 2020-09-13T12:26:41.000+00:00
+	const fromLit = "2020-09-13T12:26:40.000+00:00"
+	const toLit = "2020-09-13T12:26:41.000+00:00"
 
 	cases := []struct {
 		name string
@@ -39,37 +43,37 @@ func TestExpandTableMacros(t *testing.T) {
 		{
 			name: "timeFilter with explicit column",
 			in:   "SELECT time, s0 FROM db.t WHERE $__timeFilter(time)",
-			want: "SELECT time, s0 FROM db.t WHERE (time >= 1000 AND time <= 2000)",
+			want: "SELECT time, s0 FROM db.t WHERE (time >= " + fromLit + " AND time <= " + toLit + ")",
 		},
 		{
 			name: "timeFilter defaults to time column when empty",
 			in:   "SELECT * FROM db.t WHERE $__timeFilter()",
-			want: "SELECT * FROM db.t WHERE (time >= 1000 AND time <= 2000)",
+			want: "SELECT * FROM db.t WHERE (time >= " + fromLit + " AND time <= " + toLit + ")",
 		},
 		{
 			name: "timeFrom and timeTo",
 			in:   "SELECT * FROM db.t WHERE time >= $__timeFrom AND time <= $__timeTo",
-			want: "SELECT * FROM db.t WHERE time >= 1000 AND time <= 2000",
-		},
-		{
-			name: "no macros is unchanged",
-			in:   "SELECT * FROM db.t",
-			want: "SELECT * FROM db.t",
+			want: "SELECT * FROM db.t WHERE time >= " + fromLit + " AND time <= " + toLit,
 		},
 		{
 			name: "function form timeFrom and timeTo",
 			in:   "SELECT * FROM db.t WHERE time >= $__timeFrom() AND time <= $__timeTo( )",
-			want: "SELECT * FROM db.t WHERE time >= 1000 AND time <= 2000",
+			want: "SELECT * FROM db.t WHERE time >= " + fromLit + " AND time <= " + toLit,
 		},
 		{
 			name: "timeFilter with one nested paren level",
 			in:   "SELECT * FROM db.t WHERE $__timeFilter(cast(x))",
-			want: "SELECT * FROM db.t WHERE (cast(x) >= 1000 AND cast(x) <= 2000)",
+			want: "SELECT * FROM db.t WHERE (cast(x) >= " + fromLit + " AND cast(x) <= " + toLit + ")",
 		},
 		{
 			name: "longer identifier is not mangled",
 			in:   "SELECT $__timeFromage FROM db.t",
 			want: "SELECT $__timeFromage FROM db.t",
+		},
+		{
+			name: "no macros is unchanged",
+			in:   "SELECT * FROM db.t",
+			want: "SELECT * FROM db.t",
 		},
 	}
 
@@ -83,39 +87,94 @@ func TestExpandTableMacros(t *testing.T) {
 	}
 }
 
-func TestParseTableQueryResponseError(t *testing.T) {
-	body := []byte(`{"code":500,"message":"boom"}`)
-	ds, err := parseTableQueryResponse(body)
+func TestQuoteTableIdentifier(t *testing.T) {
+	if got := quoteTableIdentifier("test"); got != `"test"` {
+		t.Fatalf("plain identifier = %q", got)
+	}
+	if got := quoteTableIdentifier(`we"ird`); got != `"we""ird"` {
+		t.Fatalf("embedded quote = %q", got)
+	}
+}
+
+// fakeResultSet implements tableResultSet over an in-memory row list, standing
+// in for the native client's SessionDataSet (1-based column indexes).
+type fakeResultSet struct {
+	names  []string
+	types  []string
+	rows   [][]interface{}
+	cursor int
+	err    error
+	closed bool
+}
+
+func (f *fakeResultSet) Next() (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if f.cursor >= len(f.rows) {
+		return false, nil
+	}
+	f.cursor++
+	return true, nil
+}
+
+func (f *fakeResultSet) GetColumnNames() []string { return f.names }
+func (f *fakeResultSet) GetColumnTypes() []string { return f.types }
+
+func (f *fakeResultSet) GetObjectByIndex(columnIndex int32) (interface{}, error) {
+	return f.rows[f.cursor-1][columnIndex-1], nil
+}
+
+func (f *fakeResultSet) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestFetchTableDataSet(t *testing.T) {
+	rs := &fakeResultSet{
+		names: []string{"time", "device", "value"},
+		types: []string{"TIMESTAMP", "STRING", "DOUBLE"},
+		rows: [][]interface{}{
+			{ts(1000), "d1", float64(1.5)},
+			{ts(2000), nil, float64(2.5)}, // null cell passes through
+		},
+	}
+	dataSet, err := fetchTableDataSet(rs)
 	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if ds.Code != 500 || ds.Message != "boom" {
-		t.Fatalf("error status not parsed: code=%d message=%q", ds.Code, ds.Message)
+	if len(dataSet.Values) != 2 || len(dataSet.ColumnNames) != 3 {
+		t.Fatalf("unexpected shape: %d rows, %d columns", len(dataSet.Values), len(dataSet.ColumnNames))
+	}
+	if dataSet.Values[0][1] != "d1" || dataSet.Values[1][1] != nil {
+		t.Fatalf("cells not carried over: %#v", dataSet.Values)
+	}
+	if tv, ok := dataSet.Values[1][0].(time.Time); !ok || !tv.Equal(ts(2000)) {
+		t.Fatalf("time cell = %#v, want %v", dataSet.Values[1][0], ts(2000))
 	}
 }
 
-func TestParseTableQueryResponseInvalidJSON(t *testing.T) {
-	if _, err := parseTableQueryResponse([]byte("not json")); err == nil {
-		t.Fatalf("expected an error for malformed JSON")
+func TestFetchTableDataSetPropagatesError(t *testing.T) {
+	rs := &fakeResultSet{names: []string{"a"}, types: []string{"INT64"}, err: errors.New("broken pipe")}
+	if _, err := fetchTableDataSet(rs); err == nil {
+		t.Fatalf("expected the iteration error to propagate")
 	}
 }
 
-// TestBuildTableFrameRowMajor pins the response orientation: the table endpoint
-// serialises values ROW-major (values[row][col]), so a field must gather a
-// single column across every row. The two-row fixture below mirrors the shape
-// asserted by IoTDB's own IoTDBRestServiceIT.testQuery and would fail if the
-// values were read column-major.
-func TestBuildTableFrameRowMajor(t *testing.T) {
+// TestBuildTableFrameRowOrientation pins the fetch orientation contract: the
+// dataset rows are row-major (values[row][col]), so a field must gather a
+// single column across every row, with the client's native Go value types.
+func TestBuildTableFrameRowOrientation(t *testing.T) {
 	ds := &tableQueryDataSet{
 		ColumnNames: []string{"time", "i", "d", "b", "s"},
 		DataTypes:   []string{"TIMESTAMP", "INT64", "DOUBLE", "BOOLEAN", "TEXT"},
 		Values: [][]interface{}{
-			{float64(1600000000000), float64(42), float64(3.5), true, "hello"},  // row 0
-			{float64(1600000001000), float64(43), float64(4.5), false, "world"}, // row 1
+			{ts(1600000000000), int64(42), float64(3.5), true, "hello"},
+			{ts(1600000001000), int64(43), float64(4.5), false, "world"},
 		},
 	}
 
-	frame := buildTableFrame(ds, msNs)
+	frame := buildTableFrame(ds)
 	if len(frame.Fields) != 5 {
 		t.Fatalf("expected 5 fields, got %d", len(frame.Fields))
 	}
@@ -125,59 +184,48 @@ func TestBuildTableFrameRowMajor(t *testing.T) {
 		}
 	}
 
-	// time column across both rows -> *time.Time
-	if v, ok := frame.Fields[0].At(0).(*time.Time); !ok || v == nil ||
-		!v.Equal(time.Unix(0, 1600000000000*int64(time.Millisecond))) {
-		t.Fatalf("time[0] = %#v", frame.Fields[0].At(0))
-	}
-	if v, ok := frame.Fields[0].At(1).(*time.Time); !ok || v == nil ||
-		!v.Equal(time.Unix(0, 1600000001000*int64(time.Millisecond))) {
+	if v, ok := frame.Fields[0].At(1).(*time.Time); !ok || v == nil || !v.Equal(ts(1600000001000)) {
 		t.Fatalf("time[1] = %#v", frame.Fields[0].At(1))
 	}
-	// int column
 	if v := frame.Fields[1].At(0).(*int64); *v != 42 {
 		t.Fatalf("i[0] = %d, want 42", *v)
 	}
-	if v := frame.Fields[1].At(1).(*int64); *v != 43 {
-		t.Fatalf("i[1] = %d, want 43", *v)
-	}
-	// double column
 	if v := frame.Fields[2].At(1).(*float64); *v != 4.5 {
 		t.Fatalf("d[1] = %v, want 4.5", *v)
 	}
-	// boolean column
 	if v := frame.Fields[3].At(1).(*bool); *v != false {
 		t.Fatalf("b[1] = %v, want false", *v)
 	}
-	// text column
 	if v := frame.Fields[4].At(1).(*string); *v != "world" {
 		t.Fatalf("s[1] = %q, want world", *v)
 	}
 }
 
-// TestParseAndBuildPreservesInt64Precision decodes a real JSON body end-to-end
-// and checks that an INT64 above 2^53 is not corrupted (which a plain float64
-// decode would do). 9007199254740993 == 2^53 + 1 is not representable in
-// float64, so this fails unless the decoder preserves integer precision.
-func TestParseAndBuildPreservesInt64Precision(t *testing.T) {
-	body := []byte(`{"column_names":["v"],"data_types":["INT64"],"values":[[9007199254740993]]}`)
-
-	ds, err := parseTableQueryResponse(body)
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
+// TestBuildTableFieldNativeTypeCoercions pins the client-type mapping: INT32
+// widens to int64, FLOAT widens to float64, an INT64 above 2^53 stays exact
+// (native int64, no float roundtrip), DATE renders as yyyy-MM-dd and BLOB as
+// 0x-prefixed hex — the same rendering the REST transport produced.
+func TestBuildTableFieldNativeTypeCoercions(t *testing.T) {
+	if v := buildTableField("i", "INT32", []interface{}{int32(7)}).At(0).(*int64); *v != 7 {
+		t.Fatalf("INT32 = %d, want 7", *v)
 	}
-	frame := buildTableFrame(ds, msNs)
-	if len(frame.Fields) != 1 || frame.Fields[0].Len() != 1 {
-		t.Fatalf("unexpected frame shape: %d fields", len(frame.Fields))
+	if v := buildTableField("f", "FLOAT", []interface{}{float32(1.5)}).At(0).(*float64); *v != 1.5 {
+		t.Fatalf("FLOAT = %v, want 1.5", *v)
 	}
-	got := frame.Fields[0].At(0).(*int64)
-	if got == nil || *got != 9007199254740993 {
-		t.Fatalf("int64 precision lost: got %v, want 9007199254740993", got)
+	if v := buildTableField("big", "INT64", []interface{}{int64(9007199254740993)}).At(0).(*int64); *v != 9007199254740993 {
+		t.Fatalf("INT64 precision lost: %d", *v)
+	}
+	date := time.Date(2025, 7, 14, 0, 0, 0, 0, time.UTC)
+	if v := buildTableField("e", "DATE", []interface{}{date}).At(0).(*string); *v != "2025-07-14" {
+		t.Fatalf("DATE = %q, want 2025-07-14", *v)
+	}
+	if v := buildTableField("d", "BLOB", []interface{}{[]byte{0xca, 0xfe, 0xba, 0xbe}}).At(0).(*string); *v != "0xcafebabe" {
+		t.Fatalf("BLOB = %q, want 0xcafebabe", *v)
 	}
 }
 
 func TestBuildTableFieldNullsBecomeNilPointers(t *testing.T) {
-	f := buildTableField("i", "INT64", []interface{}{float64(1), nil, float64(3)}, msNs)
+	f := buildTableField("i", "INT64", []interface{}{int64(1), nil, int64(3)})
 	if f.Len() != 3 {
 		t.Fatalf("expected 3 values, got %d", f.Len())
 	}
@@ -190,7 +238,7 @@ func TestBuildTableFieldNullsBecomeNilPointers(t *testing.T) {
 }
 
 func TestBuildTableFieldUnknownTypeRendersString(t *testing.T) {
-	f := buildTableField("x", "SOMETHING_NEW", []interface{}{float64(7), "raw", nil}, msNs)
+	f := buildTableField("x", "SOMETHING_NEW", []interface{}{int64(7), "raw", nil})
 	if f.Len() != 3 {
 		t.Fatalf("expected 3 values, got %d", f.Len())
 	}
@@ -206,18 +254,17 @@ func TestBuildTableFieldUnknownTypeRendersString(t *testing.T) {
 }
 
 // TestBuildTableFrameRaggedRowIsSafe checks that a row shorter than the column
-// header (a missing trailing cell) does not panic and yields equal-length,
-// null-padded fields.
+// header does not panic and yields equal-length, null-padded fields.
 func TestBuildTableFrameRaggedRowIsSafe(t *testing.T) {
 	ds := &tableQueryDataSet{
 		ColumnNames: []string{"time", "s0"},
 		DataTypes:   []string{"TIMESTAMP", "TEXT"},
 		Values: [][]interface{}{
-			{float64(1), "a"}, // full row
-			{float64(2)},      // ragged: missing s0
+			{ts(1), "a"},
+			{ts(2)}, // ragged: missing s0
 		},
 	}
-	frame := buildTableFrame(ds, msNs)
+	frame := buildTableFrame(ds)
 	if len(frame.Fields) != 2 {
 		t.Fatalf("expected 2 fields, got %d", len(frame.Fields))
 	}
@@ -229,50 +276,6 @@ func TestBuildTableFrameRaggedRowIsSafe(t *testing.T) {
 	}
 }
 
-// TestTimestampUnits pins the precision option's conversion factors: the
-// panel's ms range must be scaled INTO server units for the macros, and raw
-// TIMESTAMP ticks must be scaled into nanoseconds for rendering.
-func TestTimestampUnits(t *testing.T) {
-	cases := []struct {
-		precision  string
-		unitsPerMs int64
-		nsPerUnit  int64
-	}{
-		{"", 1, int64(time.Millisecond)},
-		{"ms", 1, int64(time.Millisecond)},
-		{"us", 1000, int64(time.Microsecond)},
-		{"ns", 1000000, 1},
-		{" NS ", 1000000, 1},
-		{"garbage", 1, int64(time.Millisecond)},
-	}
-	for _, c := range cases {
-		unitsPerMs, nsPerUnit := timestampUnits(c.precision)
-		if unitsPerMs != c.unitsPerMs || nsPerUnit != c.nsPerUnit {
-			t.Fatalf("timestampUnits(%q) = (%d, %d), want (%d, %d)",
-				c.precision, unitsPerMs, nsPerUnit, c.unitsPerMs, c.nsPerUnit)
-		}
-	}
-}
-
-// TestBuildTableFieldTimestampPrecision renders the same instant sent by a
-// us- and an ns-precision server. With the old hard-coded ms conversion the
-// microsecond value would land in January 1970, off by 1000x.
-func TestBuildTableFieldTimestampPrecision(t *testing.T) {
-	want := time.Unix(0, 1600000000000*int64(time.Millisecond)) // 2020-09-13T12:26:40Z
-
-	_, usNs := timestampUnits("us")
-	f := buildTableField("time", "TIMESTAMP", []interface{}{float64(1600000000000000)}, usNs)
-	if v, ok := f.At(0).(*time.Time); !ok || v == nil || !v.Equal(want) {
-		t.Fatalf("us tick rendered as %#v, want %v", f.At(0), want)
-	}
-
-	_, nsNs := timestampUnits("ns")
-	f = buildTableField("time", "TIMESTAMP", []interface{}{float64(1600000000000000000)}, nsNs)
-	if v, ok := f.At(0).(*time.Time); !ok || v == nil || !v.Equal(want) {
-		t.Fatalf("ns tick rendered as %#v, want %v", f.At(0), want)
-	}
-}
-
 // TestBuildTableResponseFrameLongToWide pins the multi-device path: a long
 // result (time + tag + value), even arriving unsorted, must come back as one
 // labeled series per tag value so a time-series panel draws separate lines.
@@ -281,14 +284,14 @@ func TestBuildTableResponseFrameLongToWide(t *testing.T) {
 		ColumnNames: []string{"time", "device", "temperature"},
 		DataTypes:   []string{"TIMESTAMP", "STRING", "DOUBLE"},
 		Values: [][]interface{}{
-			{float64(2000), "d2", float64(22.5)},
-			{float64(1000), "d1", float64(11.0)},
-			{float64(1000), "d2", float64(21.0)},
-			{float64(2000), "d1", float64(12.0)},
+			{ts(2000), "d2", float64(22.5)},
+			{ts(1000), "d1", float64(11.0)},
+			{ts(1000), "d2", float64(21.0)},
+			{ts(2000), "d1", float64(12.0)},
 		},
 	}
 
-	frame := buildTableResponseFrame(ds, "", msNs)
+	frame := buildTableResponseFrame(ds, "")
 	if len(frame.Fields) != 3 {
 		t.Fatalf("expected time + one series per device (3 fields), got %d", len(frame.Fields))
 	}
@@ -327,17 +330,17 @@ func TestBuildTableResponseFrameTableFormatPreservesOrder(t *testing.T) {
 		ColumnNames: []string{"time", "device", "temperature"},
 		DataTypes:   []string{"TIMESTAMP", "STRING", "DOUBLE"},
 		Values: [][]interface{}{
-			{float64(2000), "d2", float64(22.5)},
-			{float64(1000), "d1", float64(11.0)},
+			{ts(2000), "d2", float64(22.5)},
+			{ts(1000), "d1", float64(11.0)},
 		},
 	}
 
-	frame := buildTableResponseFrame(ds, tableFormatTable, msNs)
+	frame := buildTableResponseFrame(ds, tableFormatTable)
 	if len(frame.Fields) != 3 {
 		t.Fatalf("expected 3 plain fields, got %d", len(frame.Fields))
 	}
 	first, ok := frame.Fields[0].At(0).(*time.Time)
-	if !ok || first == nil || !first.Equal(time.Unix(0, 2000*msNs)) {
+	if !ok || first == nil || !first.Equal(ts(2000)) {
 		t.Fatalf("row order changed: first time = %#v, want t=2000ms", frame.Fields[0].At(0))
 	}
 	if _, ok := frame.Fields[1].At(0).(*string); !ok {
@@ -353,16 +356,44 @@ func TestBuildTableResponseFrameNullTimeFallsBack(t *testing.T) {
 		ColumnNames: []string{"time", "device", "temperature"},
 		DataTypes:   []string{"TIMESTAMP", "STRING", "DOUBLE"},
 		Values: [][]interface{}{
-			{float64(1000), "d1", float64(11.0)},
+			{ts(1000), "d1", float64(11.0)},
 			{nil, "d2", float64(21.0)},
 		},
 	}
 
-	frame := buildTableResponseFrame(ds, tableFormatTimeSeries, msNs)
+	frame := buildTableResponseFrame(ds, tableFormatTimeSeries)
 	if len(frame.Fields) != 3 {
 		t.Fatalf("expected plain 3-field fallback frame, got %d fields", len(frame.Fields))
 	}
 	if frame.TimeSeriesSchema().Type != data.TimeSeriesTypeLong {
 		t.Fatalf("fallback frame should still be the long-shaped original")
+	}
+}
+
+func TestTableRPCEndpoint(t *testing.T) {
+	cases := []struct {
+		name       string
+		rpcAddress string
+		url        string
+		wantHost   string
+		wantPort   string
+	}{
+		{name: "derived from http url", url: "http://192.168.1.10:18080", wantHost: "192.168.1.10", wantPort: "6667"},
+		{name: "derived from url with trailing slash", url: "http://iotdb.example.com:18080/", wantHost: "iotdb.example.com", wantPort: "6667"},
+		{name: "derived from bare host and rest port", url: "192.168.1.10:18080", wantHost: "192.168.1.10", wantPort: "6667"},
+		{name: "explicit host and port", rpcAddress: "10.0.0.5:7777", url: "http://x:18080", wantHost: "10.0.0.5", wantPort: "7777"},
+		{name: "explicit bare host gets default port", rpcAddress: "10.0.0.5", url: "http://x:18080", wantHost: "10.0.0.5", wantPort: "6667"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &IoTDBDataSource{Ulr: c.url, RPCAddress: c.rpcAddress}
+			host, port, err := d.tableRPCEndpoint()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if host != c.wantHost || port != c.wantPort {
+				t.Fatalf("endpoint = %s:%s, want %s:%s", host, port, c.wantHost, c.wantPort)
+			}
+		})
 	}
 }

--- a/connectors/grafana-plugin/pkg/plugin/table_query_test.go
+++ b/connectors/grafana-plugin/pkg/plugin/table_query_test.go
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// msNs is the TIMESTAMP tick-to-nanosecond factor for a default (ms) server.
+const msNs = int64(time.Millisecond)
+
+func TestExpandTableMacros(t *testing.T) {
+	const from int64 = 1000
+	const to int64 = 2000
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "timeFilter with explicit column",
+			in:   "SELECT time, s0 FROM db.t WHERE $__timeFilter(time)",
+			want: "SELECT time, s0 FROM db.t WHERE (time >= 1000 AND time <= 2000)",
+		},
+		{
+			name: "timeFilter defaults to time column when empty",
+			in:   "SELECT * FROM db.t WHERE $__timeFilter()",
+			want: "SELECT * FROM db.t WHERE (time >= 1000 AND time <= 2000)",
+		},
+		{
+			name: "timeFrom and timeTo",
+			in:   "SELECT * FROM db.t WHERE time >= $__timeFrom AND time <= $__timeTo",
+			want: "SELECT * FROM db.t WHERE time >= 1000 AND time <= 2000",
+		},
+		{
+			name: "no macros is unchanged",
+			in:   "SELECT * FROM db.t",
+			want: "SELECT * FROM db.t",
+		},
+		{
+			name: "function form timeFrom and timeTo",
+			in:   "SELECT * FROM db.t WHERE time >= $__timeFrom() AND time <= $__timeTo( )",
+			want: "SELECT * FROM db.t WHERE time >= 1000 AND time <= 2000",
+		},
+		{
+			name: "timeFilter with one nested paren level",
+			in:   "SELECT * FROM db.t WHERE $__timeFilter(cast(x))",
+			want: "SELECT * FROM db.t WHERE (cast(x) >= 1000 AND cast(x) <= 2000)",
+		},
+		{
+			name: "longer identifier is not mangled",
+			in:   "SELECT $__timeFromage FROM db.t",
+			want: "SELECT $__timeFromage FROM db.t",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := expandTableMacros(c.in, from, to)
+			if got != c.want {
+				t.Fatalf("expandTableMacros() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseTableQueryResponseError(t *testing.T) {
+	body := []byte(`{"code":500,"message":"boom"}`)
+	ds, err := parseTableQueryResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if ds.Code != 500 || ds.Message != "boom" {
+		t.Fatalf("error status not parsed: code=%d message=%q", ds.Code, ds.Message)
+	}
+}
+
+func TestParseTableQueryResponseInvalidJSON(t *testing.T) {
+	if _, err := parseTableQueryResponse([]byte("not json")); err == nil {
+		t.Fatalf("expected an error for malformed JSON")
+	}
+}
+
+// TestBuildTableFrameRowMajor pins the response orientation: the table endpoint
+// serialises values ROW-major (values[row][col]), so a field must gather a
+// single column across every row. The two-row fixture below mirrors the shape
+// asserted by IoTDB's own IoTDBRestServiceIT.testQuery and would fail if the
+// values were read column-major.
+func TestBuildTableFrameRowMajor(t *testing.T) {
+	ds := &tableQueryDataSet{
+		ColumnNames: []string{"time", "i", "d", "b", "s"},
+		DataTypes:   []string{"TIMESTAMP", "INT64", "DOUBLE", "BOOLEAN", "TEXT"},
+		Values: [][]interface{}{
+			{float64(1600000000000), float64(42), float64(3.5), true, "hello"},  // row 0
+			{float64(1600000001000), float64(43), float64(4.5), false, "world"}, // row 1
+		},
+	}
+
+	frame := buildTableFrame(ds, msNs)
+	if len(frame.Fields) != 5 {
+		t.Fatalf("expected 5 fields, got %d", len(frame.Fields))
+	}
+	for _, f := range frame.Fields {
+		if f.Len() != 2 {
+			t.Fatalf("field %q has len %d, want 2 (row count)", f.Name, f.Len())
+		}
+	}
+
+	// time column across both rows -> *time.Time
+	if v, ok := frame.Fields[0].At(0).(*time.Time); !ok || v == nil ||
+		!v.Equal(time.Unix(0, 1600000000000*int64(time.Millisecond))) {
+		t.Fatalf("time[0] = %#v", frame.Fields[0].At(0))
+	}
+	if v, ok := frame.Fields[0].At(1).(*time.Time); !ok || v == nil ||
+		!v.Equal(time.Unix(0, 1600000001000*int64(time.Millisecond))) {
+		t.Fatalf("time[1] = %#v", frame.Fields[0].At(1))
+	}
+	// int column
+	if v := frame.Fields[1].At(0).(*int64); *v != 42 {
+		t.Fatalf("i[0] = %d, want 42", *v)
+	}
+	if v := frame.Fields[1].At(1).(*int64); *v != 43 {
+		t.Fatalf("i[1] = %d, want 43", *v)
+	}
+	// double column
+	if v := frame.Fields[2].At(1).(*float64); *v != 4.5 {
+		t.Fatalf("d[1] = %v, want 4.5", *v)
+	}
+	// boolean column
+	if v := frame.Fields[3].At(1).(*bool); *v != false {
+		t.Fatalf("b[1] = %v, want false", *v)
+	}
+	// text column
+	if v := frame.Fields[4].At(1).(*string); *v != "world" {
+		t.Fatalf("s[1] = %q, want world", *v)
+	}
+}
+
+// TestParseAndBuildPreservesInt64Precision decodes a real JSON body end-to-end
+// and checks that an INT64 above 2^53 is not corrupted (which a plain float64
+// decode would do). 9007199254740993 == 2^53 + 1 is not representable in
+// float64, so this fails unless the decoder preserves integer precision.
+func TestParseAndBuildPreservesInt64Precision(t *testing.T) {
+	body := []byte(`{"column_names":["v"],"data_types":["INT64"],"values":[[9007199254740993]]}`)
+
+	ds, err := parseTableQueryResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	frame := buildTableFrame(ds, msNs)
+	if len(frame.Fields) != 1 || frame.Fields[0].Len() != 1 {
+		t.Fatalf("unexpected frame shape: %d fields", len(frame.Fields))
+	}
+	got := frame.Fields[0].At(0).(*int64)
+	if got == nil || *got != 9007199254740993 {
+		t.Fatalf("int64 precision lost: got %v, want 9007199254740993", got)
+	}
+}
+
+func TestBuildTableFieldNullsBecomeNilPointers(t *testing.T) {
+	f := buildTableField("i", "INT64", []interface{}{float64(1), nil, float64(3)}, msNs)
+	if f.Len() != 3 {
+		t.Fatalf("expected 3 values, got %d", f.Len())
+	}
+	if v, ok := f.At(1).(*int64); !ok || v != nil {
+		t.Fatalf("null value should be a nil *int64, got %#v", f.At(1))
+	}
+	if v, ok := f.At(0).(*int64); !ok || v == nil || *v != 1 {
+		t.Fatalf("first value = %#v, want *int64(1)", f.At(0))
+	}
+}
+
+func TestBuildTableFieldUnknownTypeRendersString(t *testing.T) {
+	f := buildTableField("x", "SOMETHING_NEW", []interface{}{float64(7), "raw", nil}, msNs)
+	if f.Len() != 3 {
+		t.Fatalf("expected 3 values, got %d", f.Len())
+	}
+	if v, ok := f.At(0).(*string); !ok || v == nil || *v != "7" {
+		t.Fatalf("numeric coerced to string = %#v, want *string(7)", f.At(0))
+	}
+	if v, ok := f.At(1).(*string); !ok || v == nil || *v != "raw" {
+		t.Fatalf("string value = %#v, want *string(raw)", f.At(1))
+	}
+	if v, ok := f.At(2).(*string); !ok || v != nil {
+		t.Fatalf("null value should be nil *string, got %#v", f.At(2))
+	}
+}
+
+// TestBuildTableFrameRaggedRowIsSafe checks that a row shorter than the column
+// header (a missing trailing cell) does not panic and yields equal-length,
+// null-padded fields.
+func TestBuildTableFrameRaggedRowIsSafe(t *testing.T) {
+	ds := &tableQueryDataSet{
+		ColumnNames: []string{"time", "s0"},
+		DataTypes:   []string{"TIMESTAMP", "TEXT"},
+		Values: [][]interface{}{
+			{float64(1), "a"}, // full row
+			{float64(2)},      // ragged: missing s0
+		},
+	}
+	frame := buildTableFrame(ds, msNs)
+	if len(frame.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(frame.Fields))
+	}
+	if frame.Fields[0].Len() != 2 || frame.Fields[1].Len() != 2 {
+		t.Fatalf("fields must be equal length (2), got %d and %d", frame.Fields[0].Len(), frame.Fields[1].Len())
+	}
+	if v, ok := frame.Fields[1].At(1).(*string); !ok || v != nil {
+		t.Fatalf("missing ragged cell should be nil *string, got %#v", frame.Fields[1].At(1))
+	}
+}
+
+// TestTimestampUnits pins the precision option's conversion factors: the
+// panel's ms range must be scaled INTO server units for the macros, and raw
+// TIMESTAMP ticks must be scaled into nanoseconds for rendering.
+func TestTimestampUnits(t *testing.T) {
+	cases := []struct {
+		precision  string
+		unitsPerMs int64
+		nsPerUnit  int64
+	}{
+		{"", 1, int64(time.Millisecond)},
+		{"ms", 1, int64(time.Millisecond)},
+		{"us", 1000, int64(time.Microsecond)},
+		{"ns", 1000000, 1},
+		{" NS ", 1000000, 1},
+		{"garbage", 1, int64(time.Millisecond)},
+	}
+	for _, c := range cases {
+		unitsPerMs, nsPerUnit := timestampUnits(c.precision)
+		if unitsPerMs != c.unitsPerMs || nsPerUnit != c.nsPerUnit {
+			t.Fatalf("timestampUnits(%q) = (%d, %d), want (%d, %d)",
+				c.precision, unitsPerMs, nsPerUnit, c.unitsPerMs, c.nsPerUnit)
+		}
+	}
+}
+
+// TestBuildTableFieldTimestampPrecision renders the same instant sent by a
+// us- and an ns-precision server. With the old hard-coded ms conversion the
+// microsecond value would land in January 1970, off by 1000x.
+func TestBuildTableFieldTimestampPrecision(t *testing.T) {
+	want := time.Unix(0, 1600000000000*int64(time.Millisecond)) // 2020-09-13T12:26:40Z
+
+	_, usNs := timestampUnits("us")
+	f := buildTableField("time", "TIMESTAMP", []interface{}{float64(1600000000000000)}, usNs)
+	if v, ok := f.At(0).(*time.Time); !ok || v == nil || !v.Equal(want) {
+		t.Fatalf("us tick rendered as %#v, want %v", f.At(0), want)
+	}
+
+	_, nsNs := timestampUnits("ns")
+	f = buildTableField("time", "TIMESTAMP", []interface{}{float64(1600000000000000000)}, nsNs)
+	if v, ok := f.At(0).(*time.Time); !ok || v == nil || !v.Equal(want) {
+		t.Fatalf("ns tick rendered as %#v, want %v", f.At(0), want)
+	}
+}
+
+// TestBuildTableResponseFrameLongToWide pins the multi-device path: a long
+// result (time + tag + value), even arriving unsorted, must come back as one
+// labeled series per tag value so a time-series panel draws separate lines.
+func TestBuildTableResponseFrameLongToWide(t *testing.T) {
+	ds := &tableQueryDataSet{
+		ColumnNames: []string{"time", "device", "temperature"},
+		DataTypes:   []string{"TIMESTAMP", "STRING", "DOUBLE"},
+		Values: [][]interface{}{
+			{float64(2000), "d2", float64(22.5)},
+			{float64(1000), "d1", float64(11.0)},
+			{float64(1000), "d2", float64(21.0)},
+			{float64(2000), "d1", float64(12.0)},
+		},
+	}
+
+	frame := buildTableResponseFrame(ds, "", msNs)
+	if len(frame.Fields) != 3 {
+		t.Fatalf("expected time + one series per device (3 fields), got %d", len(frame.Fields))
+	}
+	if frame.Fields[0].Len() != 2 {
+		t.Fatalf("expected 2 wide rows, got %d", frame.Fields[0].Len())
+	}
+	byDevice := map[string][]float64{}
+	for _, f := range frame.Fields[1:] {
+		dev := f.Labels["device"]
+		if dev == "" {
+			t.Fatalf("value field %q has no device label: %v", f.Name, f.Labels)
+		}
+		var vals []float64
+		for i := 0; i < f.Len(); i++ {
+			v, ok := f.At(i).(*float64)
+			if !ok || v == nil {
+				t.Fatalf("field %q row %d = %#v, want *float64", f.Name, i, f.At(i))
+			}
+			vals = append(vals, *v)
+		}
+		byDevice[dev] = vals
+	}
+	if v := byDevice["d1"]; len(v) != 2 || v[0] != 11.0 || v[1] != 12.0 {
+		t.Fatalf("d1 series = %v, want [11 12]", v)
+	}
+	if v := byDevice["d2"]; len(v) != 2 || v[0] != 21.0 || v[1] != 22.5 {
+		t.Fatalf("d2 series = %v, want [21 22.5]", v)
+	}
+}
+
+// TestBuildTableResponseFrameTableFormatPreservesOrder pins that the Table
+// format neither re-sorts rows (the user's ORDER BY wins) nor pivots tags
+// into labels.
+func TestBuildTableResponseFrameTableFormatPreservesOrder(t *testing.T) {
+	ds := &tableQueryDataSet{
+		ColumnNames: []string{"time", "device", "temperature"},
+		DataTypes:   []string{"TIMESTAMP", "STRING", "DOUBLE"},
+		Values: [][]interface{}{
+			{float64(2000), "d2", float64(22.5)},
+			{float64(1000), "d1", float64(11.0)},
+		},
+	}
+
+	frame := buildTableResponseFrame(ds, tableFormatTable, msNs)
+	if len(frame.Fields) != 3 {
+		t.Fatalf("expected 3 plain fields, got %d", len(frame.Fields))
+	}
+	first, ok := frame.Fields[0].At(0).(*time.Time)
+	if !ok || first == nil || !first.Equal(time.Unix(0, 2000*msNs)) {
+		t.Fatalf("row order changed: first time = %#v, want t=2000ms", frame.Fields[0].At(0))
+	}
+	if _, ok := frame.Fields[1].At(0).(*string); !ok {
+		t.Fatalf("tag column should stay a plain string field in Table format")
+	}
+}
+
+// TestBuildTableResponseFrameNullTimeFallsBack pins the safety net: when the
+// long-to-wide pivot cannot apply (here: a null timestamp), the plain frame is
+// returned instead of an error or a panic.
+func TestBuildTableResponseFrameNullTimeFallsBack(t *testing.T) {
+	ds := &tableQueryDataSet{
+		ColumnNames: []string{"time", "device", "temperature"},
+		DataTypes:   []string{"TIMESTAMP", "STRING", "DOUBLE"},
+		Values: [][]interface{}{
+			{float64(1000), "d1", float64(11.0)},
+			{nil, "d2", float64(21.0)},
+		},
+	}
+
+	frame := buildTableResponseFrame(ds, tableFormatTimeSeries, msNs)
+	if len(frame.Fields) != 3 {
+		t.Fatalf("expected plain 3-field fallback frame, got %d fields", len(frame.Fields))
+	}
+	if frame.TimeSeriesSchema().Type != data.TimeSeriesTypeLong {
+		t.Fatalf("fallback frame should still be the long-shaped original")
+	}
+}

--- a/connectors/grafana-plugin/src/ConfigEditor.tsx
+++ b/connectors/grafana-plugin/src/ConfigEditor.tsx
@@ -15,19 +15,13 @@
  * limitations under the License.
  */
 import React, { ChangeEvent, PureComponent } from 'react';
-import { InlineField, Input, SecretInput, Select } from '@grafana/ui';
-import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
+import { InlineField, Input, SecretInput } from '@grafana/ui';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { IoTDBOptions, IoTDBSecureJsonData } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<IoTDBOptions, IoTDBSecureJsonData> {}
 
 interface State {}
-
-const timestampPrecisions: Array<SelectableValue<string>> = [
-  { label: 'ms', value: 'ms' },
-  { label: 'us', value: 'us' },
-  { label: 'ns', value: 'ns' },
-];
 
 export class ConfigEditor extends PureComponent<Props, State> {
   onURLChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -48,11 +42,11 @@ export class ConfigEditor extends PureComponent<Props, State> {
     onOptionsChange({ ...options, jsonData });
   };
 
-  onTimestampPrecisionChange = (option: SelectableValue<string>) => {
+  onRPCAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onOptionsChange, options } = this.props;
     const jsonData = {
       ...options.jsonData,
-      timestampPrecision: option.value ?? 'ms',
+      rpcAddress: event.target.value,
     };
     onOptionsChange({ ...options, jsonData });
   };
@@ -117,14 +111,14 @@ export class ConfigEditor extends PureComponent<Props, State> {
           />
         </InlineField>
         <InlineField
-          label="time precision"
+          label="rpc address"
           labelWidth={12}
-          tooltip="Must match the server's timestamp_precision property (ms by default). Used by the SQL: Table Model mode to interpret TIMESTAMP values and expand the $__timeFilter / $__timeFrom / $__timeTo macros."
+          tooltip="The IoTDB RPC endpoint (host or host:port) used by the SQL: Table Model mode's native client. Leave empty to use the URL's host with the default RPC port 6667."
         >
-          <Select
-            options={timestampPrecisions}
-            value={timestampPrecisions.find((o) => o.value === (jsonData.timestampPrecision ?? 'ms'))}
-            onChange={this.onTimestampPrecisionChange}
+          <Input
+            onChange={this.onRPCAddressChange}
+            value={jsonData.rpcAddress || ''}
+            placeholder="iotdb-host:6667 (optional)"
             width={40}
           />
         </InlineField>

--- a/connectors/grafana-plugin/src/ConfigEditor.tsx
+++ b/connectors/grafana-plugin/src/ConfigEditor.tsx
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 import React, { ChangeEvent, PureComponent } from 'react';
-import { InlineField, Input, SecretInput } from '@grafana/ui';
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { InlineField, Input, SecretInput, Select } from '@grafana/ui';
+import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
 import { IoTDBOptions, IoTDBSecureJsonData } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<IoTDBOptions, IoTDBSecureJsonData> {}
 
 interface State {}
+
+const timestampPrecisions: Array<SelectableValue<string>> = [
+  { label: 'ms', value: 'ms' },
+  { label: 'us', value: 'us' },
+  { label: 'ns', value: 'ns' },
+];
 
 export class ConfigEditor extends PureComponent<Props, State> {
   onURLChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -38,6 +44,15 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const jsonData = {
       ...options.jsonData,
       username: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
+  onTimestampPrecisionChange = (option: SelectableValue<string>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      timestampPrecision: option.value ?? 'ms',
     };
     onOptionsChange({ ...options, jsonData });
   };
@@ -99,6 +114,18 @@ export class ConfigEditor extends PureComponent<Props, State> {
             width={40}
             onReset={this.onResetPassword}
             onChange={this.onPasswordChange}
+          />
+        </InlineField>
+        <InlineField
+          label="time precision"
+          labelWidth={12}
+          tooltip="Must match the server's timestamp_precision property (ms by default). Used by the SQL: Table Model mode to interpret TIMESTAMP values and expand the $__timeFilter / $__timeFrom / $__timeTo macros."
+        >
+          <Select
+            options={timestampPrecisions}
+            value={timestampPrecisions.find((o) => o.value === (jsonData.timestampPrecision ?? 'ms'))}
+            onChange={this.onTimestampPrecisionChange}
+            width={40}
           />
         </InlineField>
       </div>

--- a/connectors/grafana-plugin/src/QueryEditor.tsx
+++ b/connectors/grafana-plugin/src/QueryEditor.tsx
@@ -389,7 +389,7 @@ export class QueryEditor extends PureComponent<Props, State> {
                   <QueryInlineField label={'DATABASE'}>
                     <Input
                       value={query.database ?? this.state.database}
-                      placeholder={'database name (optional if the query is fully qualified)'}
+                      placeholder={'database name (required)'}
                       onChange={this.onDatabaseChange}
                     />
                   </QueryInlineField>

--- a/connectors/grafana-plugin/src/QueryEditor.tsx
+++ b/connectors/grafana-plugin/src/QueryEditor.tsx
@@ -26,7 +26,7 @@ import { FromValue } from './componments/FromValue';
 import { WhereValue } from './componments/WhereValue';
 import { ControlValue } from './componments/ControlValue';
 import { FillValue } from './componments/FillValue';
-import { Segment } from '@grafana/ui';
+import { Input, Segment, TextArea } from '@grafana/ui';
 import { toOption } from './functions';
 
 import { GroupByLabel } from './componments/GroupBy';
@@ -46,6 +46,9 @@ interface State {
   isDropDownList: boolean;
   sqlType: string;
   shouldAdd: boolean;
+  database: string;
+  sql: string;
+  format: string;
 }
 
 const selectElement = [
@@ -64,7 +67,8 @@ const selectElement = [
 
 const paths = [''];
 const expressions = [''];
-const selectType = ['SQL: Full Customized', 'SQL: Drop-down List'];
+const selectType = ['SQL: Full Customized', 'SQL: Drop-down List', 'SQL: Table Model'];
+const tableFormats = ['Time series', 'Table'];
 const commonOption: SelectableValue<string> = { label: '*', value: '*' };
 const commonOptionDou: SelectableValue<string> = { label: '**', value: '**' };
 type Props = QueryEditorProps<DataSource, IoTDBQuery, IoTDBOptions>;
@@ -87,6 +91,9 @@ export class QueryEditor extends PureComponent<Props, State> {
     isDropDownList: false,
     sqlType: selectType[0],
     shouldAdd: true,
+    database: '',
+    sql: '',
+    format: tableFormats[0],
   };
 
 
@@ -134,7 +141,26 @@ export class QueryEditor extends PureComponent<Props, State> {
     onChange({ ...query, groupBy: g });
   };
 
-  
+  onDatabaseChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onChange, query } = this.props;
+    const database = event.target.value;
+    this.setState({ database });
+    onChange({ ...query, database });
+  };
+
+  onSqlChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const { onChange, query } = this.props;
+    const sql = event.target.value;
+    this.setState({ sql });
+    onChange({ ...query, sql });
+  };
+
+  onFormatChange = ({ value: value = tableFormats[0] }: SelectableValue<string>) => {
+    const { onChange, query } = this.props;
+    this.setState({ format: value });
+    onChange({ ...query, format: value });
+  };
+
   onSelectTypeChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onChange, query } = this.props;
     onChange({ ...query });
@@ -175,7 +201,13 @@ export class QueryEditor extends PureComponent<Props, State> {
  
   componentDidMount() {
     if (this.props.query.sqlType) {
-      this.setState({ isDropDownList: this.props.query.isDropDownList, sqlType: this.props.query.sqlType });
+      this.setState({
+        isDropDownList: this.props.query.isDropDownList,
+        sqlType: this.props.query.sqlType,
+        database: this.props.query.database ?? '',
+        sql: this.props.query.sql ?? '',
+        format: this.props.query.format ?? tableFormats[0],
+      });
     } else {
       this.props.query.sqlType = selectType[0];
     }
@@ -231,7 +263,7 @@ export class QueryEditor extends PureComponent<Props, State> {
                       condition: '',
                     });
                     onChange({ ...query, sqlType: value, isDropDownList: false });
-                  } else {
+                  } else if (value === selectType[1]) {
                     this.props.query.sqlType = selectType[1];
                     this.props.query.expression = [''];
                     this.props.query.prefixPath = [''];
@@ -247,6 +279,22 @@ export class QueryEditor extends PureComponent<Props, State> {
                       control: '',
                     });
                     onChange({ ...query, sqlType: value, isDropDownList: true });
+                  } else {
+                    this.props.query.sqlType = selectType[2];
+                    this.props.query.expression = [''];
+                    this.props.query.prefixPath = [''];
+                    this.props.query.condition = '';
+                    this.props.query.control = '';
+                    this.props.query.isDropDownList = false;
+                    this.setState({
+                      isDropDownList: false,
+                      sqlType: selectType[2],
+                      expression: [''],
+                      prefixPath: [''],
+                      condition: '',
+                      control: '',
+                    });
+                    onChange({ ...query, sqlType: value, isDropDownList: false });
                   }
                 }}
                 options={selectType.map(toOption)}
@@ -254,7 +302,7 @@ export class QueryEditor extends PureComponent<Props, State> {
                 className="query-keyword width-10"
               />
             </div>
-            {!this.state.isDropDownList && (
+            {this.state.sqlType === selectType[0] && (
               <>
                 <div className="gf-form">
                   <QueryInlineField label={'SELECT'}>
@@ -330,6 +378,39 @@ export class QueryEditor extends PureComponent<Props, State> {
                     <FillValue
                       fill={fillClauses ? fillClauses : this.state.fillClauses}
                       onChange={this.onFillsChange}
+                    />
+                  </QueryInlineField>
+                </div>
+              </>
+            )}
+            {this.state.sqlType === selectType[2] && (
+              <>
+                <div className="gf-form">
+                  <QueryInlineField label={'DATABASE'}>
+                    <Input
+                      value={query.database ?? this.state.database}
+                      placeholder={'database name (optional if the query is fully qualified)'}
+                      onChange={this.onDatabaseChange}
+                    />
+                  </QueryInlineField>
+                </div>
+                <div className="gf-form">
+                  <QueryInlineField label={'SQL'}>
+                    <TextArea
+                      rows={4}
+                      value={query.sql ?? this.state.sql}
+                      placeholder={'SELECT time, s0 FROM my_table WHERE $__timeFilter(time)'}
+                      onChange={this.onSqlChange}
+                    />
+                  </QueryInlineField>
+                </div>
+                <div className="gf-form">
+                  <QueryInlineField label={'FORMAT'}>
+                    <Segment
+                      onChange={this.onFormatChange}
+                      options={tableFormats.map(toOption)}
+                      value={query.format ?? this.state.format}
+                      className="query-keyword width-10"
                     />
                   </QueryInlineField>
                 </div>

--- a/connectors/grafana-plugin/src/datasource.ts
+++ b/connectors/grafana-plugin/src/datasource.ts
@@ -126,6 +126,13 @@ export class DataSource extends DataSourceWithBackend<IoTDBQuery, IoTDBOptions> 
       if (query.fillClauses) {
         query.fillClauses = getTemplateSrv().replace(query.fillClauses, scopedVars);
       }
+    } else if (query.sqlType === 'SQL: Table Model') {
+      if (query.sql) {
+        query.sql = getTemplateSrv().replace(query.sql, scopedVars);
+      }
+      if (query.database) {
+        query.database = getTemplateSrv().replace(query.database, scopedVars);
+      }
     }
     return query;
   }

--- a/connectors/grafana-plugin/src/types.ts
+++ b/connectors/grafana-plugin/src/types.ts
@@ -65,10 +65,10 @@ export interface LimitAll {
 export interface IoTDBOptions extends DataSourceJsonData {
   url: string;
   username: string;
-  // Mirrors the server's timestamp_precision property (ms / us / ns, ms when
-  // unset). The table-model mode uses it to interpret TIMESTAMP values and to
-  // expand the time macros.
-  timestampPrecision?: string;
+  // The IoTDB RPC endpoint (host or host:port) used by the table-model mode's
+  // native client. When empty, the URL's host with the default RPC port 6667
+  // is used.
+  rpcAddress?: string;
 }
 
 /**

--- a/connectors/grafana-plugin/src/types.ts
+++ b/connectors/grafana-plugin/src/types.ts
@@ -33,6 +33,13 @@ export interface IoTDBQuery extends DataQuery {
   limitAll?: LimitAll;
   options: Array<Array<SelectableValue<string>>>;
   hide: boolean;
+
+  // Table-model mode: a standard SQL statement run against `database`,
+  // rendered either as time series (long results are pivoted into one series
+  // per tag combination) or as a plain table.
+  database?: string;
+  sql?: string;
+  format?: string;
 }
 
 export interface GroupBy {
@@ -58,6 +65,10 @@ export interface LimitAll {
 export interface IoTDBOptions extends DataSourceJsonData {
   url: string;
   username: string;
+  // Mirrors the server's timestamp_precision property (ms / us / ns, ms when
+  // unset). The table-model mode uses it to interpret TIMESTAMP values and to
+  // expand the time macros.
+  timestampPrecision?: string;
 }
 
 /**


### PR DESCRIPTION
## What

Adds table-model query support to the IoTDB Grafana data source plugin — the first slice of #18258.

The plugin previously only spoke the tree model: both QueryEditor modes build `root.*` paths and the backend calls `/grafana/v1/query/expression`, which has no table-model equivalent, so table-model users could not visualize their data.

## How

- **New QueryEditor mode "SQL: Table Model"** — a database field, a SQL editor and a result format option, alongside the existing "SQL: Full Customized" and "SQL: Drop-down List" modes.
- **Native-client backend** (per review): queries run through [apache/iotdb-client-go](https://github.com/apache/iotdb-client-go) v2.0.8 (`TableSession`) against the RPC port, served by a lazily created per-datasource `TableSessionPool`. A new optional `rpc address` datasource setting configures the endpoint (defaults to the URL's host with port 6667). Tree-model queries and the health check keep using the REST service for now.
- **Typed, nullable fields driven by the result set's data types** — TIMESTAMP → time (converted by the client with the server-reported timestamp precision), INT32/INT64 → int64, FLOAT/DOUBLE → float64, BOOLEAN → bool, DATE/BLOB/TEXT/others → string — with INT64 precision preserved end-to-end (native values, no JSON).
- **Multi-device results render as separate series**: in the default `Time series` format, rows are sorted by the first TIMESTAMP column and a long-shaped result (time + tag columns + value columns) is pivoted with the SDK's `data.LongToWide`, turning tag columns into field labels — `SELECT time, device_id, temperature FROM t` draws one line per device instead of one interleaved series. The `Table` format returns rows untouched (preserves a user's `ORDER BY`). If the pivot cannot apply (e.g. null timestamps), the plain frame is returned.
- **`$__timeFilter(col)` / `$__timeFrom` / `$__timeTo` macros** expand to ISO 8601 UTC timestamp literals for the panel's range, which the server parses under any configured `timestamp_precision`; the function forms `$__timeFrom()` / `$__timeTo()` familiar from Grafana's SQL data sources are accepted too, and `$__timeFilter` allows one level of nested parentheses.
- **README**: documents the new mode, the rpc address setting, the macros, the format option and the `LIMIT` recommendation for wide scans.

## Testing

- Backend: `go build`, `go vet`, and `go test ./pkg/plugin` (13 unit tests) pass — covering macro expansion (incl. function forms and nested parentheses), the result-set fetch path (behind a narrow interface, incl. nulls and error propagation), per-type conversion incl. DATE/BLOB rendering and INT64 precision, the long-to-wide pivot for multi-device results (incl. unsorted input and the null-timestamp fallback), Table-format row-order preservation, and RPC endpoint resolution.
- Frontend: type-checked with `tsc --noEmit` against the `@grafana` types.
- The client contract was verified against the iotdb-client-go v2.0.8 sources (`TableSession`, `SessionDataSet` typed getters, server-reported time precision) and the server's relational planner (`ignoreTimestamp` semantics). It has not yet been smoke-tested against a live server.

## Follow-ups (same issue)

The `@grafana/toolkit` → `@grafana/create-plugin` toolchain migration (next PR, as discussed), a database → table → column browser, a visual query builder, frontend Jest coverage for the new mode, path-picker performance, and moving the tree-model path and health check to the native client as part of the broader modernization.
