### PR TITLE
Correct the date_bin timezone statement in IoTDBTableTimeseriesDao's Javadoc

### DIFF
--- a/iotdb-thingsboard-table/src/main/java/org/apache/iotdb/extras/thingsboard/table/IoTDBTableTimeseriesDao.java
+++ b/iotdb-thingsboard-table/src/main/java/org/apache/iotdb/extras/thingsboard/table/IoTDBTableTimeseriesDao.java
@@ -389,14 +389,16 @@ public class IoTDBTableTimeseriesDao extends IoTDBTableBaseDao
    * <p>IoTDB 2.0.8's native {@code date_bin} calendar primitive cannot reproduce ThingsBoard's
    * boundaries: it anchors each calendar bucket on the <em>origin's day-of-month</em> (so {@code
    * date_bin(1mo, time, startTs)} from a mid-month {@code startTs} steps day-15 → day-15, not to
-   * the 1st of each month) and it exposes <em>no timezone argument</em> (it computes in the
-   * server's UTC zone only). ThingsBoard instead advances {@code startTs} to the start of the next
-   * calendar unit in {@code tzId} via {@link TimeUtils#calculateIntervalEnd}, so the first bucket
-   * is the partial {@code [startTs, nextCalendarBoundary)} and later buckets are full calendar
-   * units. This path therefore reproduces ThingsBoard exactly the way ThingsBoard itself does: it
-   * walks the calendar boundaries in Java and issues one bounded aggregate query per bucket
-   * (ThingsBoard issues one future per bucket), reusing the very same projection, row mapper and
-   * typed-COUNT logic as the {@code MILLISECONDS} path.
+   * the 1st of each month) and it exposes <em>no timezone argument</em> — its calendar arithmetic
+   * runs in the <em>session's</em> zone, which is fixed when the session pool is built and cannot
+   * be rebound per query, while each {@link ReadTsKvQuery} carries its own {@code tzId}.
+   * ThingsBoard instead advances {@code startTs} to the start of the next calendar unit in {@code
+   * tzId} via {@link TimeUtils#calculateIntervalEnd}, so the first bucket is the partial {@code
+   * [startTs, nextCalendarBoundary)} and later buckets are full calendar units. This path therefore
+   * reproduces ThingsBoard exactly the way ThingsBoard itself does: it walks the calendar
+   * boundaries in Java and issues one bounded aggregate query per bucket (ThingsBoard issues one
+   * future per bucket), reusing the very same projection, row mapper and typed-COUNT logic as the
+   * {@code MILLISECONDS} path.
    *
    * <p>Walking {@code [startTs, endPeriod)} where {@code endPeriod = max(startTs + 1, endTs)}: each
    * iteration takes {@code bucketStart = startPeriod}, {@code bucketEnd = min(calculateIntervalEnd(


### PR DESCRIPTION
The calendar-aggregation Javadoc I added in #115 says `date_bin`

> exposes *no timezone argument* (it computes in the server's UTC zone only).

The first half is right; **the parenthetical is wrong**, and it was wrong when I wrote it rather than having gone stale.

`DateBinFunctionColumnTransformer.dateBin(long source, long origin, int monthDuration, long nonMonthDuration, ZoneId zoneId)` converts through `LocalDateTime` in that `ZoneId`, and `ColumnTransformerBuilder`'s `DATE_BIN` branch passes `context.sessionInfo.getZoneId()` — identically at `v2.0.8` (the version the Javadoc names) and on `master`. It has never been UTC-only. `TableSessionPoolBuilder.zoneId(...)` even defaults to `ZoneId.systemDefault()`, so UTC is not the default either.

The design decision the paragraph justifies does not change: this path still has to walk calendar boundaries in Java. But the accurate reason is different, and it is a stronger one — the zone is **session-scoped**, fixed when the session pool is built, so a pooled session cannot rebind it per query, whereas each `ReadTsKvQuery` carries its own `tzId`. The day-of-month anchoring half of the original sentence stands unchanged.

Comment-only change; no behaviour is affected. Verified `mvn -P with-thingsboard compile` and applied `spotless:apply` (which reflowed the surrounding paragraph, hence the slightly larger diff).