### PR TITLE
Keep real ThingsBoard verification isolated

### DIFF
--- a/iotdb-thingsboard-table/VERIFYING-AGAINST-THINGSBOARD.md
+++ b/iotdb-thingsboard-table/VERIFYING-AGAINST-THINGSBOARD.md
@@ -131,7 +131,7 @@ A green build proves nothing on its own: if the compile-only sources are still o
 the source path, everything compiles exactly as before. Check the compiler line.
 
 ```
-with the compile-only surface:     Compiling 58 source files
+with the compile-only surface:     Compiling 59 source files
 with the real artifacts:           Compiling 19 source files
 ```
 
@@ -142,26 +142,37 @@ tells you nothing about the real types.
 `mvn -P with-thingsboard -pl iotdb-thingsboard-table dependency:list | grep thingsboard`
 should also list the real artifacts at `provided` scope.
 
-## Result on 2026-08-10, against ThingsBoard 4.3.1.2
+## Result on 2026-08-25, against ThingsBoard 4.3.1.2
 
 ```
-Compiling 19 source files            (58 with the compile-only surface)
-Tests run: 190, Failures: 0, Errors: 0      unit
-Tests run:  57, Failures: 0, Errors: 0      container ITs, real IoTDB
+Compiling 19 source files            (59 with the compile-only surface)
+Tests run: 204, Failures: 0, Errors: 0      unit
+Tests run:  58, Failures: 0, Errors: 0      container ITs, real IoTDB
 BUILD SUCCESS
 ```
 
 Integration tests by suite: `IoTDBTableLatestDaoIT` 19,
-`IoTDBTableTimeseriesAggregationIT` 13, `IoTDBTableAttributesDaoIT` 12,
+`IoTDBTableTimeseriesAggregationIT` 14, `IoTDBTableAttributesDaoIT` 12,
 `IoTDBTableTimeseriesDaoIT` 10, `IoTDBTableTtlIT` 2,
 `IoTDBTableIngestionBenchmarkIT` 1.
+
+The context-test fixture marks its test-only `JpaAttributeDao` bean lazy. With
+the genuine ThingsBoard class in place, eagerly constructing that bean would
+also require ThingsBoard's host-provided `jpaExecutorService`, which this
+isolated module test intentionally does not bootstrap. The tests exercise bean
+definition selection and removal; the lazy marker prevents an unrelated host
+dependency from changing that scope and does not affect production code. Those
+context assertions therefore do not prove that the host DAO itself can be
+constructed in this isolated runner; host-application compatibility requires a
+separate live ThingsBoard deployment.
 
 No drift: every type in the compile-only surface matched, and all three
 `implements` clauses bound against the real interfaces.
 
-This has not been run inside a live ThingsBoard instance. It establishes that the
-types bind and that the DAO behaves correctly against a real IoTDB while using
-them; it does not establish that ThingsBoard as a whole runs on this DAO.
+This verification procedure does not launch a live ThingsBoard instance. It
+establishes that the types bind and that the DAO behaves correctly against a
+real IoTDB while using them; it does not establish that ThingsBoard as a whole
+runs on this DAO.
 
 ## When ThingsBoard publishes its artifacts
 

--- a/iotdb-thingsboard-table/src/test/java/org/apache/iotdb/extras/thingsboard/table/AttributesDaoConflictGuardTest.java
+++ b/iotdb-thingsboard-table/src/test/java/org/apache/iotdb/extras/thingsboard/table/AttributesDaoConflictGuardTest.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
 import org.thingsboard.server.dao.attributes.AttributesDao;
@@ -228,10 +229,16 @@ class AttributesDaoConflictGuardTest {
    * method would resolve only to {@code AttributesDao} and the guard would classify it as
    * unrecognised and refuse to start -- correctly, since at that point nothing distinguishes it
    * from a third-party backend.
+   *
+   * <p>The fixture is lazy because these tests exercise bean-definition selection, not the host DAO
+   * itself. Constructing the genuine ThingsBoard class would otherwise require host-only
+   * collaborators such as {@code jpaExecutorService}, which this isolated module context does not
+   * bootstrap.
    */
   @Configuration(proxyBeanMethods = false)
   static class HostAttributesDaoConfiguration {
     @Bean(name = HOST_DAO_BEAN)
+    @Lazy
     JpaAttributeDao jpaAttributeDao() {
       return new JpaAttributeDao();
     }


### PR DESCRIPTION
## Description

### Isolate the context-test fixture

Mark the test-only `JpaAttributeDao` fixture lazy. The context tests exercise bean-definition selection and withdrawal; they do not exercise the host DAO itself. Against genuine ThingsBoard 4.3.1.2 types, eager construction also requires host-application collaborators such as `jpaExecutorService`, which this isolated module test intentionally does not bootstrap.

This changes no production code. The verification guide now states the resulting proof boundary explicitly: these context assertions cover definition selection, while host-application compatibility requires a separate live ThingsBoard deployment.

### Refresh genuine-interface verification evidence

Update `VERIFYING-AGAINST-THINGSBOARD.md` with the current genuine-type surface and test counts after #125:

- compile-only build: 59 source files
- genuine ThingsBoard 4.3.1.2 build: 19 source files
- unit tests: 204 passed
- Docker integration tests: 58 passed
- failures, errors, and skipped tests: 0

The built module contains no `org/thingsboard` classes.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for the modified test behavior.
- [x] added comments explaining the intent of the test fixture.
- [x] been tested against genuine ThingsBoard 4.3.1.2 types and a real IoTDB 2.0.8 Testcontainer.

<hr>

##### Key changed classes and documents

- `AttributesDaoConflictGuardTest`
- `VERIFYING-AGAINST-THINGSBOARD.md`